### PR TITLE
Correct link to documentation

### DIFF
--- a/README
+++ b/README
@@ -63,7 +63,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 **Documentation** 
 
-see http://matplotlib.gitub.net/basemap.
+see http://matplotlib.github.com/basemap/
 
 see scripts in 'examples' directory for example usage.
 


### PR DESCRIPTION
The link to the docs in the README didn't work.
