### PR TITLE
fix missing Europe coastlines

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+since version 1.0.3 release
+---------------------------
+* fix bug that caused Europe coastlines to disappear from some maps
+  (evident from nytolondon.py example).
 * fix splitting of parallels in conic projections that cross the dateline
   (issue 40).
 

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -1023,6 +1023,15 @@ class Basemap(object):
                     crossdatelineE = True
                 elif id.endswith('W'):
                     crossdatelineW = True
+            # make sure south/north limits of dateline crossing polygons
+            # (Eurasia) are the same, since they will be merged into one.
+            # (this avoids having one filtered out and not the other).
+            if crossdatelineE:
+                south_save=south
+                north_save=north
+            if crossdatelineW: 
+                south=south_save
+                north=north_save
             if area < 0.: area = 1.e30
             useit = self.latmax>=south and self.latmin<=north and area>self.area_thresh
             if useit:


### PR DESCRIPTION
on plot sthat crossed the Greenwich meridian (evident in nytolondon.py example).
