### PR TITLE
Fix allskymap.py on Python 2.x

### DIFF
--- a/examples/allskymap.py
+++ b/examples/allskymap.py
@@ -73,7 +73,7 @@ class AllSkyMap(Basemap):
                        suppress_ticks=True,
                        boundinglat=None,
                        fix_aspect=True,
-                       anchor='C',
+                       anchor=str('C'),
                        ax=None):
 
         if projection != 'hammer' and projection !='moll':


### PR DESCRIPTION
The `allskymap_cr_example.py` example from basemap 1.0.4 fails on Python 2.7 because `anchor` is a unicode type:

```
Parsed data for 27 UHE CRs...
Parsed data for 18 candidate sources...
Exception in Tkinter callback
Traceback (most recent call last):
  File "X:\Python27\lib\lib-tk\Tkinter.py", line 1410, in __call__
    return self.func(*args)
  File "X:\Python27\lib\site-packages\matplotlib\backends\backend_tkagg.py", line 236, in resize
    self.show()
  File "X:\Python27\lib\site-packages\matplotlib\backends\backend_tkagg.py", line 239, in draw
    FigureCanvasAgg.draw(self)
  File "X:\Python27\lib\site-packages\matplotlib\backends\backend_agg.py", line 421, in draw
    self.figure.draw(self.renderer)
  File "X:\Python27\lib\site-packages\matplotlib\artist.py", line 55, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "X:\Python27\lib\site-packages\matplotlib\figure.py", line 898, in draw
    func(*args)
  File "X:\Python27\lib\site-packages\matplotlib\artist.py", line 55, in draw_wrapper
    draw(artist, renderer, *args, **kwargs)
  File "X:\Python27\lib\site-packages\matplotlib\axes.py", line 1900, in draw
    self.apply_aspect()
  File "X:\Python27\lib\site-packages\matplotlib\axes.py", line 1164, in apply_aspect
    self.set_position(pb1.anchored(self.get_anchor(), pb), 'active')
  File "X:\Python27\lib\site-packages\matplotlib\transforms.py", line 523, in anchored
    cx, cy = c
ValueError: need more than 1 value to unpack
```
