### PR TITLE
`geos_c` library not needed on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ if sys.platform == 'win32':
     extensions.append(Extension("_geoslib",['src/_geoslib.c'],
                                 library_dirs=geos_library_dirs,
                                 include_dirs=geos_include_dirs,
-                                libraries=['geos_c','geos']))
+                                libraries=['geos']))
 else:
     #extensions.append(Extension("mpl_toolkits.basemap._geoslib",['src/_geoslib.c'],
     extensions.append(Extension("_geoslib",['src/_geoslib.c'],


### PR DESCRIPTION
See "Building Basemap on Windows" on the matplotlib-users mailing list  http://matplotlib.1069221.n5.nabble.com/Building-Basemap-on-Windows-td38719.html
