### PR TITLE
Extended shiftgrid to arbitrary dimensions.

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4919,7 +4919,8 @@ def shiftgrid(lon0,datain,lonsin,start=True,cyclic=360.0):
     lon0             starting longitude for shifted grid
                      (ending longitude if start=False). lon0 must be on
                      input grid (within the range of lonsin).
-    datain           original data.
+    datain           original data with longitude the right-most
+                     dimension.
     lonsin           original longitudes.
     ==============   ====================================================
 
@@ -4958,20 +4959,12 @@ def shiftgrid(lon0,datain,lonsin,start=True,cyclic=360.0):
         lonsout[0:i0_shift] = lonsin[i0:]
     else:
         lonsout[0:i0_shift] = lonsin[i0:]-cyclic
-    if datain.ndim == 2:
-        dataout[:,0:i0_shift] = datain[:,i0:]
-    elif datain.ndim == 1:
-        dataout[0:i0_shift] = datain[i0:]
-    else:
-        raise ValueError('data must be 1d or 2d with longitude as 2nd dim')
+    dataout[...,0:i0_shift] = datain[...,i0:]
     if start:
         lonsout[i0_shift:] = lonsin[start_idx:i0+start_idx]+cyclic
     else:
         lonsout[i0_shift:] = lonsin[start_idx:i0+start_idx]
-    if datain.ndim == 2:
-       dataout[:,i0_shift:] = datain[:,start_idx:i0+start_idx]
-    elif datain.ndim == 1:
-       dataout[i0_shift:] = datain[start_idx:i0+start_idx]
+    dataout[...,i0_shift:] = datain[...,start_idx:i0+start_idx]
     return dataout,lonsout
 
 def addcyclic(arrin,lonsin):


### PR DESCRIPTION
n-dimensional arrays can be passed to shiftgrid, provided that longitude is the last (right-most) dimension.
