### PR TITLE
use short names for submodule imports to ease imports out of mpl_toolkit...

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -27,7 +27,7 @@ from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.patches import Ellipse, Circle, Polygon, FancyArrowPatch
 from matplotlib.lines import Line2D
 from matplotlib.transforms import Bbox
-from mpl_toolkits.basemap import pyproj
+import pyproj # imports local version
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.image import imread
 import sys, os, math

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -27,7 +27,7 @@ from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.patches import Ellipse, Circle, Polygon, FancyArrowPatch
 from matplotlib.lines import Line2D
 from matplotlib.transforms import Bbox
-import pyproj # imports local version
+from . import pyproj # imports local version
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.image import imread
 import sys, os, math

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -27,7 +27,7 @@ from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.patches import Ellipse, Circle, Polygon, FancyArrowPatch
 from matplotlib.lines import Line2D
 from matplotlib.transforms import Bbox
-from . import pyproj # imports local version
+from . import pyproj
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.image import imread
 import sys, os, math

--- a/lib/mpl_toolkits/basemap/proj.py
+++ b/lib/mpl_toolkits/basemap/proj.py
@@ -1,5 +1,5 @@
 import numpy as np
-from . import pyproj # import local version
+from . import pyproj
 import math
 from matplotlib.cbook import dedent
 

--- a/lib/mpl_toolkits/basemap/proj.py
+++ b/lib/mpl_toolkits/basemap/proj.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mpl_toolkits.basemap import pyproj
+import pyproj # import local version
 import math
 from matplotlib.cbook import dedent
 

--- a/lib/mpl_toolkits/basemap/proj.py
+++ b/lib/mpl_toolkits/basemap/proj.py
@@ -1,5 +1,5 @@
 import numpy as np
-import pyproj # import local version
+from . import pyproj # import local version
 import math
 from matplotlib.cbook import dedent
 

--- a/lib/mpl_toolkits/basemap/pyproj.py
+++ b/lib/mpl_toolkits/basemap/pyproj.py
@@ -47,7 +47,7 @@ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
 NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. """
 
-from mpl_toolkits.basemap import _proj
+from . import _proj # import local version
 __version__ =  _proj.__version__
 set_datapath =  _proj.set_datapath
 from array import array

--- a/lib/mpl_toolkits/basemap/pyproj.py
+++ b/lib/mpl_toolkits/basemap/pyproj.py
@@ -47,7 +47,7 @@ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
 NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. """
 
-from . import _proj # import local version
+from . import _proj
 __version__ =  _proj.__version__
 set_datapath =  _proj.set_datapath
 from array import array


### PR DESCRIPTION
...s

It is difficult to import the basemap module when it is not installed
along with the rest of the mpl_toolkits package. This change uses local
imports in the basemap package for submodules with potentially
conflicting global modules. This way it is easier to include the basemap
package when it is installed in a different location (e.g. a virtualenv
using system mpl_toolkits).

Python ensures that an import first looks in the containing package when
importing, this way it is not necessary to specify the full module name:

https://docs.python.org/2/tutorial/modules.html#intra-package-references

It addresses issues like:
http://stackoverflow.com/questions/18772557/how-can-one-locally-install-an-extension-to-an-existing-system-python-module