### PR TITLE
Allow basemap to be installed using pip, virtualenv and a requirements.txt file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,25 @@
-import sys, glob, os, numpy, subprocess
+import sys, glob, os, subprocess
+
 major, minor1, minor2, s, tmp = sys.version_info
 if major==2 and minor1<4 or major<2:
     raise SystemExit("""matplotlib and the basemap toolkit require Python 2.4 or later.""")
-from numpy.distutils.core  import setup, Extension
+
+from distutils.core import setup, Extension
+from distutils.dist import Distribution
 from distutils.util import convert_path
 from distutils import ccompiler, sysconfig
+
+# Do not require numpy for just querying the package
+# Taken from the netcdf-python setup file (which took it from h5py setup file).
+inc_dirs = []
+if any('--' + opt in sys.argv for opt in Distribution.display_option_names +
+       ['help-commands', 'help']) or sys.argv[1] == 'egg_info':
+    pass
+else:
+    # append numpy include dir.
+    import numpy
+    inc_dirs.append(numpy.get_include())
+
 try:
     from distutils.command.build_py import build_py_2to3 as build_py
 except ImportError:
@@ -62,7 +77,7 @@ set GEOS_DIR to /usr/local), or edit the setup.py script
 manually and set the variable GEOS_dir (right after the line
 that says "set GEOS_dir manually here".""" % "', '".join(geos_search_locations))
 else:
-    geos_include_dirs=[os.path.join(GEOS_dir,'include'),numpy.get_include()]
+    geos_include_dirs=[os.path.join(GEOS_dir,'include'),inc_dirs]
     geos_library_dirs=[os.path.join(GEOS_dir,'lib'),os.path.join(GEOS_dir,'lib64')]
 
 # proj4 and geos extensions.
@@ -130,6 +145,7 @@ setup(
   download_url      = "https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-{0}/basemap-{0}.tar.gz".format(__version__),
   author            = "Jeff Whitaker",
   author_email      = "jeffrey.s.whitaker@noaa.gov",
+  install_requires  = ["numpy>=1.2.1", "matplotlib>=1.0.0"],
   platforms         = ["any"],
   license           = "OSI Approved",
   keywords          = ["python","plotting","plots","graphs","charts","GIS","mapping","map projections","maps"],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ major, minor1, minor2, s, tmp = sys.version_info
 if major==2 and minor1<4 or major<2:
     raise SystemExit("""matplotlib and the basemap toolkit require Python 2.4 or later.""")
 
-from distutils.core import setup, Extension
 from distutils.dist import Distribution
 from distutils.util import convert_path
 from distutils import ccompiler, sysconfig
@@ -14,10 +13,12 @@ from distutils import ccompiler, sysconfig
 inc_dirs = []
 if any('--' + opt in sys.argv for opt in Distribution.display_option_names +
        ['help-commands', 'help']) or sys.argv[1] == 'egg_info':
-    pass
+    from distutils.core import setup, Extension
 else:
-    # append numpy include dir.
     import numpy
+    # Use numpy versions if they are available.
+    from numpy.distutils.core import setup, Extension
+    # append numpy include dir.
     inc_dirs.append(numpy.get_include())
 
 try:


### PR DESCRIPTION
I ran into problems trying to install basemap using pip, virtualenv and a requirements.txt file. On installation, it tries to use setup.py to check the egg_info, and when it does this it throws an `ImportError` because numpy has not yet been installed (it is also in the requirements.txt file). 

Another project, [netcdf4-python](https://github.com/Unidata/netcdf4-python), had this problem and solved it by checking to see which command was being used with setup.py and only installing numpy if it was during installation: https://github.com/Unidata/netcdf4-python/commit/18f21a2ae2c21531f7d3bf8610cbc27cf2df2381. I copied the idea, with the main change being that setup.py still uses setup and Extensions from numpy during installation, as I wasn't sure if this was important and didn't want to break things for anyone.

The fix can be checked using a virtualenv. Create a virtualenv:

    virtualenv basemap_env
    cd basemap_env
    source bin/activate
    pip install -r requirements.txt

requirements.txt (works OK):

    numpy
    matplotlib
    git+https://github.com/markmuetz/basemap.git@pip_install#egg=basemap

requirements.txt (doesn't work)

    numpy
    matplotlib
    git+https://github.com/markmuetz/basemap.git@master#egg=basemap
    # or can just be:
    # basemap
