### PR TITLE
Do not call shiftdata for scattter plots

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -544,9 +544,9 @@ def _transform1d(plotfunc):
                     # shift longitudes to be in the range lon_0 +/- 180
                     lon_0 = self.projparams["lon_0"]
                     try:
-                        delta = (x - lon_0) % 360 + lon_0
+                        delta = (x - lon_0) % 360
                     except TypeError:
-                        delta = [(xx - lon_0) % 360 + lon_0 for xx in x]
+                        delta = [(xx - lon_0) % 360 for xx in x]
 
                     delta = np.asarray(delta)
                     delta[delta > 180] -= 360

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -540,6 +540,19 @@ def _transform1d(plotfunc):
                 elif x.ndim == 0:
                     if x > 180:
                         x = x - 360.
+                elif plotfunc.__name__ == "scatter":
+                    # shift longitudes to be in the range lon_0 +/- 180
+                    lon_0 = self.projparams["lon_0"]
+                    try:
+                        delta = (x - lon_0) % 360 + lon_0
+                    except TypeError:
+                        delta = [(xx - lon_0) % 360 + lon_0 for xx in x]
+
+                    delta = np.asarray(delta)
+                    delta[delta > 180] -= 360
+                    delta[delta <= -180] += 360
+                    x = lon_0 + delta
+
             # convert lat/lon coords to map projection coords.
             x, y = self(x,y)
         return plotfunc(self,x,y,*args,**kwargs)
@@ -1140,6 +1153,9 @@ class Basemap(object):
                 lon_0=self.projparams['lon_0']
             else:
                 lon_0 = 0.
+
+
+
         if self.celestial and not inverse:
             try:
                 x = 2.*lon_0-x

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -534,7 +534,8 @@ def _transform1d(plotfunc):
             # shift data to map projection region for
             # cylindrical and pseudo-cylindrical projections.
             if self.projection in _cylproj or self.projection in _pseudocyl:
-                if x.ndim == 1:
+                # shiftdata assumes a regular grid, which is not always true for scatter plots
+                if x.ndim == 1 and plotfunc.__name__ != "scatter":
                     x = self.shiftdata(x)
                 elif x.ndim == 0:
                     if x > 180:

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -155,19 +155,6 @@ class TestProj(TestCase):
             assert_almost_equal(b(x, y, inverse=True), (lon, lat), decimal=2, err_msg="{} is not invertible ({}, {}) not  <-> ({}, {})".format(pr, lon, lat, *b(x, y, inverse=True)))
 
 
-    def test_cyl_should_not_be_far_from_lon_0(self):
-
-        lon_0 = 0
-        b = Basemap(lon_0=lon_0)
-
-        lon, lat = 450, 80
-
-        x, y = b(lon, lat)
-
-        print(b(x, y, inverse=True))
-
-        assert abs(x - lon_0) < 180, "result longitude {} is not in {} +/- 180 range".format(x, lon_0)
-
 
 
 def test():

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -170,6 +170,8 @@ def test():
     runner.run(rotatevector_suite)
     runner.run(shiftgrid_suite)
     runner.run(unittest.makeSuite(TestScatter, 'test'))
+    runner.run(unittest.makeSuite(TestProj, 'test'))
+
 
 
 if __name__ == '__main__':

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -135,6 +135,7 @@ class TestProj(TestCase):
     def setUp(self):
         from mpl_toolkits import basemap
         self.all_projections = basemap._projnames
+        self.cyl_proj_list = basemap._cylproj + basemap._pseudocyl
 
     def test_should_be_invertible(self):
         lon, lat = 30, 60
@@ -153,8 +154,19 @@ class TestProj(TestCase):
 
             assert_almost_equal(b(x, y, inverse=True), (lon, lat), decimal=2, err_msg="{} is not invertible ({}, {}) not  <-> ({}, {})".format(pr, lon, lat, *b(x, y, inverse=True)))
 
-    def test_cyl_should_not_be_far_from_lon_0:
-        pass
+
+    def test_cyl_should_not_be_far_from_lon_0(self):
+
+        lon_0 = 0
+        b = Basemap(lon_0=lon_0)
+
+        lon, lat = 450, 80
+
+        x, y = b(lon, lat)
+
+        print(b(x, y, inverse=True))
+
+        assert abs(x - lon_0) < 180, "result longitude {} is not in {} +/- 180 range".format(x, lon_0)
 
 
 

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -130,6 +130,31 @@ class TestScatter(TestCase):
             m1.scatter(x[:1], y[:1], latlon=True)
 
 
+class TestProj(TestCase):
+
+    def setUp(self):
+        from mpl_toolkits import basemap
+        self.all_projections = basemap._projnames
+
+    def test_should_be_invertible(self):
+        lon, lat = 30, 60
+
+        for pr in self.all_projections:
+
+            if pr in ["rotpole", "tmerc", "geos", "nsper", "laea", "ortho", "poly", "gnom"]:
+                continue
+
+            bounding_lat = 30 if pr not in ["splaea", ] else -30
+            lat = bounding_lat * lat / abs(bounding_lat)
+
+            b = Basemap(projection=pr, lon_0=0, lat_0=0, llcrnrlon=-140, llcrnrlat=40, urcrnrlon=-120, urcrnrlat=60,
+                        boundinglat=bounding_lat, lat_1=30, lat_2=60, lon_1=-180, lon_2=180)
+            x, y = b(lon, lat)
+
+            assert_almost_equal(b(x, y, inverse=True), (lon, lat), decimal=2, err_msg="{} is not invertible ({}, {}) not  <-> ({}, {})".format(pr, lon, lat, *b(x, y, inverse=True)))
+
+    def test_cyl_should_not_be_far_from_lon_0:
+        pass
 
 
 

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -98,6 +98,10 @@ class TestShiftGrid(TestCase):
 
 class TestScatter(TestCase):
 
+    def setUp(self):
+        from mpl_toolkits import basemap
+        self.cyl_proj_list = basemap._cylproj + basemap._pseudocyl
+
     def get_coords(self):
         x = [-5.435, -6.660817, -119.2511944, 17.719833]
         y = [36.136, 4.746717, 39.4030278, -14.657583]
@@ -112,6 +116,21 @@ class TestScatter(TestCase):
         m = Basemap(projection='merc', lon_0=115, resolution='c')
         x, y = self.get_coords()
         m.scatter(x, y, 50, marker='o', color='g', latlon=True, zorder=10)
+
+    def test_2points_should_not_fail(self):
+        x, y = self.get_coords()
+        for pr in self.cyl_proj_list:
+            m1 = Basemap(projection=pr, lon_0=0)
+            m1.scatter(x[:2], y[:2], latlon=True)
+
+    def test_1point_should_not_fail(self):
+        x, y = self.get_coords()
+        for pr in self.cyl_proj_list:
+            m1 = Basemap(projection=pr, lon_0=0)
+            m1.scatter(x[:1], y[:1], latlon=True)
+
+
+
 
 
 def test():

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -96,6 +96,24 @@ class TestShiftGrid(TestCase):
         assert (grid==gridout).all()
 
 
+class TestScatter(TestCase):
+
+    def get_coords(self):
+        x = [-5.435, -6.660817, -119.2511944, 17.719833]
+        y = [36.136, 4.746717, 39.4030278, -14.657583]
+        return x, y
+
+    def test_not_sorted_longitudes_robin(self):
+        m = Basemap(projection='robin', lon_0=115, resolution='c')
+        x, y = self.get_coords()
+        m.scatter(x, y, 50, marker='o', color='g', latlon=True, zorder=10)
+
+    def test_not_sorted_longitudes_mer(self):
+        m = Basemap(projection='merc', lon_0=115, resolution='c')
+        x, y = self.get_coords()
+        m.scatter(x, y, 50, marker='o', color='g', latlon=True, zorder=10)
+
+
 def test():
     """
     Run some tests.
@@ -103,9 +121,13 @@ def test():
     import unittest
     rotatevector_suite = unittest.makeSuite(TestRotateVector,'test')
     shiftgrid_suite = unittest.makeSuite(TestShiftGrid,'test')
+
+
     runner = unittest.TextTestRunner()
     runner.run(rotatevector_suite)
     runner.run(shiftgrid_suite)
+    runner.run(unittest.makeSuite(TestScatter, 'test'))
+
 
 if __name__ == '__main__':
     test()


### PR DESCRIPTION
I've added a test for the scatter function and modified the decorator to eliminate the call to shiftdata for scatter in 1-d case, since I am not really sure why it is needed.... 

Addresses the issue #197.


Cheers  