### PR TITLE
Lenient shapefile field parsing

### DIFF
--- a/lib/mpl_toolkits/basemap/shapefile.py
+++ b/lib/mpl_toolkits/basemap/shapefile.py
@@ -58,7 +58,7 @@ def u(v):
     if PYTHON3:
         if isinstance(v, bytes):
             # For python 3 decode bytes to str.
-            return v.decode(default_encoding)
+            return v.decode(default_encoding, errors="replace")
         elif isinstance(v, str):
             # Already str.
             return v


### PR DESCRIPTION
Plots the shape file even in the case when some fields are not decoded successfully (sometimes we even do not care, it does replace unknown symbols usually with ?..). The code and the file that did not work before and do work with this modification are below:

```python
# Should be run in Ipython notebook
%matplotlib inline
from mpl_toolkits.basemap import Basemap
b = Basemap()
b.drawcoastlines()
b.readshapefile("network/network", "river", color="r")
b.river_info
```

The shape file can be downloaded from here: https://dl.dropboxusercontent.com/u/4629759/network.zip

This PR addresses issue #187 

Cheers
