### PR TITLE
Change spelling error: ucrnrlon to urcrnrlon

### DIFF
--- a/doc/users/figures/geos_partial.py
+++ b/doc/users/figures/geos_partial.py
@@ -11,7 +11,7 @@ ax = fig.add_axes([0.1,0.1,0.8,0.8],axisbg='k')
 # plot just upper right quadrant (corners determined from global map).
 # keywords llcrnrx,llcrnry,urcrnrx,urcrnry used to define the lower
 # left and upper right corners in map projection coordinates.
-# llcrnrlat,llcrnrlon,ucrnrlon,urcrnrlat could be used to define
+# llcrnrlat,llcrnrlon,urcrnrlon,urcrnrlat could be used to define
 # lat/lon values of corners - but this won't work in cases such as this
 # where one of the corners does not lie on the earth.
 m = Basemap(projection='geos',lon_0=lon_0,resolution='l',\

--- a/doc/users/figures/nsper_partial.py
+++ b/doc/users/figures/nsper_partial.py
@@ -14,7 +14,7 @@ ax = fig.add_axes([0.1,0.1,0.8,0.8],axisbg='k')
 # plot just upper right quadrant (corners determined from global map).
 # keywords llcrnrx,llcrnry,urcrnrx,urcrnry used to define the lower
 # left and upper right corners in map projection coordinates.
-# llcrnrlat,llcrnrlon,ucrnrlon,urcrnrlat could be used to define
+# llcrnrlat,llcrnrlon,urcrnrlon,urcrnrlat could be used to define
 # lat/lon values of corners - but this won't work in cases such as this
 # where one of the corners does not lie on the earth.
 m = Basemap(projection='nsper',satellite_height=h*1000.,\

--- a/doc/users/figures/ortho_partial.py
+++ b/doc/users/figures/ortho_partial.py
@@ -11,7 +11,7 @@ ax = fig.add_axes([0.1,0.1,0.8,0.8],axisbg='k')
 # plot just upper right quadrant (corners determined from global map).
 # keywords llcrnrx,llcrnry,urcrnrx,urcrnry used to define the lower
 # left and upper right corners in map projection coordinates.
-# llcrnrlat,llcrnrlon,ucrnrlon,urcrnrlat could be used to define
+# llcrnrlat,llcrnrlon,urcrnrlon,urcrnrlat could be used to define
 # lat/lon values of corners - but this won't work in cases such as this
 # where one of the corners does not lie on the earth.
 m = Basemap(projection='ortho',lon_0=lon_0,lat_0=lat_0,resolution='l',\

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -712,7 +712,7 @@ class Basemap(object):
                     self.urcrnrlon = urcrnrlon; self.urcrnrlat = urcrnrlat
                 else:
                     if width is None or height is None:
-                        raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,ucrnrlon,urcrnrlat) in degrees or width and height in meters')
+                        raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat) in degrees or width and height in meters')
                     if lon_0 is None or lat_0 is None:
                         raise ValueError('must specify lon_0 and lat_0 when using width, height to specify projection region')
                     llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat = _choosecorners(width,height,**projparams)
@@ -725,7 +725,7 @@ class Basemap(object):
                 raise ValueError('must specify lat_0 and lon_0 for Stereographic basemap (lat_ts is optional)')
             if not using_corners:
                 if width is None or height is None:
-                    raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,ucrnrlon,urcrnrlat) in degrees or width and height in meters')
+                    raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat) in degrees or width and height in meters')
                 if lon_0 is None or lat_0 is None:
                     raise ValueError('must specify lon_0 and lat_0 when using width, height to specify projection region')
                 llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat = _choosecorners(width,height,**projparams)
@@ -762,7 +762,7 @@ class Basemap(object):
                 raise ValueError('must specify lat_0 and lon_0 for Lambert Azimuthal basemap')
             if not using_corners:
                 if width is None or height is None:
-                    raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,ucrnrlon,urcrnrlat) in degrees or width and height in meters')
+                    raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat) in degrees or width and height in meters')
                 if lon_0 is None or lat_0 is None:
                     raise ValueError('must specify lon_0 and lat_0 when using width, height to specify projection region')
                 llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat = _choosecorners(width,height,**projparams)
@@ -777,7 +777,7 @@ class Basemap(object):
                 raise ValueError('must specify lat_0 and lon_0 for Transverse Mercator, Gnomonic, Cassini-Soldnerr and Polyconic basemap')
             if not using_corners:
                 if width is None or height is None:
-                    raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,ucrnrlon,urcrnrlat) in degrees or width and height in meters')
+                    raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat) in degrees or width and height in meters')
                 if lon_0 is None or lat_0 is None:
                     raise ValueError('must specify lon_0 and lat_0 when using width, height to specify projection region')
                 llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat = _choosecorners(width,height,**projparams)
@@ -871,7 +871,7 @@ class Basemap(object):
             #    raise ValueError, 'cannot specify map region with width and height keywords for this projection, please specify lat/lon values of corners'
             if not using_corners:
                 if width is None or height is None:
-                    raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,ucrnrlon,urcrnrlat) in degrees or width and height in meters')
+                    raise ValueError('must either specify lat/lon values of corners (llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat) in degrees or width and height in meters')
                 if lon_0 is None or lat_0 is None:
                     raise ValueError('must specify lon_0 and lat_0 when using width, height to specify projection region')
                 llcrnrlon,llcrnrlat,urcrnrlon,urcrnrlat = _choosecorners(width,height,**projparams)


### PR DESCRIPTION
There are a few spelling errors in the docs: the argument name `ucrnrlon` is supposed to be `urcrnrlon`.