### PR TITLE
Fix URL / name of GSHHG coastline database in docs

### DIFF
--- a/doc/users/geography.rst
+++ b/doc/users/geography.rst
@@ -3,8 +3,8 @@
 Drawing a Map Background
 ========================
 
-Basemap includes the 
-`GSSH <http://www.soest.hawaii.edu/wessel/gshhs/gshhs.html>`_
+Basemap includes the GSSH
+`(now GSHHG <https://www.soest.hawaii.edu/pwessel/gshhg/>)`_
 coastline dataset, as well as datasets for rivers, state and
 country boundaries from 
 `GMT <http://gmt.soest.hawaii.edu>`_.

--- a/doc/users/geography.rst
+++ b/doc/users/geography.rst
@@ -3,8 +3,8 @@
 Drawing a Map Background
 ========================
 
-Basemap includes the GSSH
-`(now GSHHG <https://www.soest.hawaii.edu/pwessel/gshhg/>)`_
+Basemap includes the GSSH (now
+`GSHHG <https://www.soest.hawaii.edu/pwessel/gshhg/>`)
 coastline dataset, as well as datasets for rivers, state and
 country boundaries from 
 `GMT <http://gmt.soest.hawaii.edu>`_.

--- a/doc/users/geography.rst
+++ b/doc/users/geography.rst
@@ -4,7 +4,7 @@ Drawing a Map Background
 ========================
 
 Basemap includes the GSSH (now
-`GSHHG <https://www.soest.hawaii.edu/pwessel/gshhg/>`)
+`GSHHG <https://www.soest.hawaii.edu/pwessel/gshhg/>`_)
 coastline dataset, as well as datasets for rivers, state and
 country boundaries from 
 `GMT <http://gmt.soest.hawaii.edu>`_.


### PR DESCRIPTION
It's now GSHHG and has a different URL: https://www.soest.hawaii.edu/pwessel/gshhg/