### PR TITLE
makes netCDF4 optional for examples/run_all.py

### DIFF
--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -16,6 +16,7 @@ try:
     from netCDF4 import Dataset
 except ImportError:
     # remove tests requiring netCDF4
+    sys.stdout.write("Could not import netCDF4, skipping tests that require netCDF4.\n")
     test_files.remove('streamplot_demo.py')
     test_files.remove('plotprecip.py')
     test_files.remove('test_rotpole.py')

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -12,6 +12,16 @@ test_files.remove('embedding_map_in_wx.py') # requires wx
 test_files.remove('plothighsandlows.py') # requires scipy
 test_files.remove('lic_demo.py')
 test_files.remove('testwmsimage.py')
+try:
+    from netCDF4 import Dataset
+except ImportError:
+    # remove tests requiring netCDF4
+    test_files.remove('streamplot_demo.py')
+    test_files.remove('plotprecip.py')
+    test_files.remove('test_rotpole.py')
+    test_files.remove('ccsm_popgrid.py')
+    test_files.remove('ploticos.py')
+
 py_path = os.environ.get('PYTHONPATH')
 if py_path is None:
     py_path = '.'


### PR DESCRIPTION
If you do not have netCDF4 installed, some example tests will give ImportErrors.

This patch makes netCDF4 optional for run_all.py.  It imports netCDF4, if that package is not available, it removes tests that require netCDF4.

There may be some of the tests in the lines above the try-statement that could be put below the except-statement.  I did not look at that aspect.