### PR TITLE
Add package_versions() and option to print ver. info in test.py

### DIFF
--- a/.requirements-2.6.txt
+++ b/.requirements-2.6.txt
@@ -1,1 +1,2 @@
+argparse
 unittest2

--- a/.requirements-2.6.txt
+++ b/.requirements-2.6.txt
@@ -1,2 +1,1 @@
-argparse
 unittest2

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,5 @@ install:
   - python setup.py install
 
 script:
-    - python lib/mpl_toolkits/basemap/test.py
+    - python lib/mpl_toolkits/basemap/test.py --verbose
 

--- a/lib/mpl_toolkits/basemap/diagnostic.py
+++ b/lib/mpl_toolkits/basemap/diagnostic.py
@@ -34,7 +34,12 @@ def package_versions():
     except ImportError:
         pil_version = 'not installed'
         pillow_version = 'not installed'
-
+    
+    # Get PROJ.4 version info in a floating point number
+    proj_ver_num = pyproj.Proj(init='epsg:4326').proj_version
+    # reformats floating point number into string (4.90 becomes '4.9.0')
+    proj4_version = '.'.join(list(str(int(proj_ver_num*100))))
+    
     BasemapPackageVersions = namedtuple(
                                'BasemapPackageVersions',
                                """Python, basemap, matplotlib,
@@ -48,7 +53,7 @@ def package_versions():
                    numpy = numpy_version,
                    pyproj = pyproj.__version__,
                    pyshp = pyshp_version,
-                   PROJ4 = round(pyproj.Proj(init='epsg:4326').proj_version, 2),
+                   PROJ4 = proj4_version,
                    GEOS = _geoslib.__geos_version__,
                    # optional dependencies below
                    OWSLib = OWSLib_version,

--- a/lib/mpl_toolkits/basemap/diagnostic.py
+++ b/lib/mpl_toolkits/basemap/diagnostic.py
@@ -1,0 +1,56 @@
+"""
+These are diagnostic and debugging functions for basemap.
+"""
+
+def package_versions():
+    """
+    Gives version information for dependent packages.
+
+    returns namedtuple BasemapPackageVersions
+    """
+    from collections import namedtuple
+    from sys import version as sys_version
+
+    from matplotlib import __version__ as matplotlib_version
+    from numpy import __version__ as numpy_version
+    import pyproj
+    from shapefile import __version__ as pyshp_version
+
+    import _geoslib
+    from mpl_toolkits.basemap import __version__ as basemap_version
+    
+    # import optional dependencies
+    try:
+        from OWSLib import __version__ as OWSLib_version
+    except ImportError:
+        OWSLib_version = 'not installed'
+
+    try:
+        from PIL import VERSION as pil_version
+        try:
+            from PIL import PILLOW_VERSION as pillow_version
+        except ImportError:
+            pillow_verison = 'not installed'
+    except ImportError:
+        pil_version = 'not installed'
+        pillow_verison = 'not installed'
+
+    BasemapPackageVersions = namedtuple(
+                               'BasemapPackageVersions',
+                               """Python, basemap, matplotlib,
+                                  numpy, pyproj, pyshp, PROJ4, GEOS,
+                                  OWSLib, PIL, Pillow""")
+
+    return BasemapPackageVersions(
+                   Python = sys_version,
+                   basemap = basemap_version,
+                   matplotlib = matplotlib_version,
+                   numpy = numpy_version,
+                   pyproj = pyproj.__version__,
+                   pyshp = pyshp_version,
+                   PROJ4 = pyproj.Proj(init='epsg:4326').proj_version,
+                   GEOS = _geoslib.__geos_version__,
+                   # optional dependencies below
+                   OWSLib = OWSLib_version,
+                   PIL = pil_version,
+                   Pillow = pillow_version)

--- a/lib/mpl_toolkits/basemap/diagnostic.py
+++ b/lib/mpl_toolkits/basemap/diagnostic.py
@@ -30,10 +30,10 @@ def package_versions():
         try:
             from PIL import PILLOW_VERSION as pillow_version
         except ImportError:
-            pillow_verison = 'not installed'
+            pillow_version = 'not installed'
     except ImportError:
         pil_version = 'not installed'
-        pillow_verison = 'not installed'
+        pillow_version = 'not installed'
 
     BasemapPackageVersions = namedtuple(
                                'BasemapPackageVersions',

--- a/lib/mpl_toolkits/basemap/diagnostic.py
+++ b/lib/mpl_toolkits/basemap/diagnostic.py
@@ -48,7 +48,7 @@ def package_versions():
                    numpy = numpy_version,
                    pyproj = pyproj.__version__,
                    pyshp = pyshp_version,
-                   PROJ4 = pyproj.Proj(init='epsg:4326').proj_version,
+                   PROJ4 = round(pyproj.Proj(init='epsg:4326').proj_version, 2),
                    GEOS = _geoslib.__geos_version__,
                    # optional dependencies below
                    OWSLib = OWSLib_version,

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -224,7 +224,7 @@ if __name__ == '__main__':
     if VERBOSITY != None:
         pkg_vers = package_versions()
         print('Basemaps installed package versions:')
-        print('{}\n'.format(pkg_vers))
+        print('{0}\n'.format(pkg_vers))
 
     unittest.main()
 

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -206,5 +206,25 @@ def test():
 
 
 if __name__ == '__main__':
+    # When called with the -v / --verbose commandline parameter, it will
+    # give package dependent version information:
+    #   $ python test.py --verbose
+
+    import argparse # standard module in Python >= 2.7 and >= 3.2
     import unittest
+
+    from mpl_toolkits.basemap.diagnostic import package_versions
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose',action='count')
+    args = parser.parse_args()
+    
+    # VERBOSITY will default to None if not a parameter
+    VERBOSITY = vars(args)['verbose']
+    if VERBOSITY != None:
+        pkg_vers = package_versions()
+        print('Basemaps installed package versions:')
+        print('{}\n'.format(pkg_vers))
+
     unittest.main()
+

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -210,18 +210,12 @@ if __name__ == '__main__':
     # give package dependent version information:
     #   $ python test.py --verbose
 
-    import argparse # standard module in Python >= 2.7 and >= 3.2
+    import sys
     import unittest
 
     from mpl_toolkits.basemap.diagnostic import package_versions
     
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-v', '--verbose',action='count')
-    args = parser.parse_args()
-    
-    # VERBOSITY will default to None if not a parameter
-    VERBOSITY = vars(args)['verbose']
-    if VERBOSITY != None:
+    if '--verbose' in sys.argv or '-v' in sys.argv:
         pkg_vers = package_versions()
         print('Basemaps installed package versions:')
         print('{0}\n'.format(pkg_vers))


### PR DESCRIPTION
package_versions() is a new function that returns a namedtuple of dependent package's version information.  It should also be useful to see if Travis is running the correct package versions.  I made this with Issue #235 in mind.  A --verbose option was added to test.py to display this version information.  Additionally, this new function could help with debugging future issues.

Example excerpt output from test.py:
>~/prj/basemap-master/lib/mpl_toolkits/basemap$ ~/prj/bmtest/bin/python3 test.py -v
Basemaps installed package versions
BasemapPackageVersions(Python='3.4.3+ (default, Oct 14 2015, 16:03:50) \n[GCC 5.2.1 20151010]', basemap='1.0.8', matplotlib='1.5.0', numpy='1.10.2', pyproj='1.9.4', pyshp='1.2.3', PROJ4=4.9, GEOS=b'3.5.0-CAPI-1.9.0 r4084', OWSLib='not installed', PIL='1.1.7', Pillow='3.0.0')

>test_convert (`__main__`.TestProjectCoords) ... skipped 'Test skipped in Python 3.x with pyproj version 1.9.4 and below.'