### PR TITLE
stops ResourceWarnings for unclosed files

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -1460,6 +1460,8 @@ class Basemap(object):
                             if not as_polygons or len(b) > 4:
                                 polygons.append(list(zip(b[:,0],b[:,1])))
                                 polygon_types.append(typ)
+        bdatfile.close()
+        bdatmetafile.close()
         return polygons, polygon_types
 
     def _getmapboundary(self):


### PR DESCRIPTION
Closes files bdatfile and bdatmetafile in the _readboundarydata function. 

This solves warnings like these on Python 3.x:
```
/.../lib/python3.4/site-packages/mpl_toolkits/basemap/__init__.py:1087: ResourceWarning: unclosed file <_io.TextIOWrapper name='/.../lib/python3.4/site-packages/mpl_toolkits/basemap/data/gshhsmeta_c.dat' mode='r' encoding='UTF-8'>
  self._readboundarydata('gshhs',as_polygons=True)
/.../python3.4/site-packages/mpl_toolkits/basemap/__init__.py:1095: ResourceWarning: unclosed file <_io.BufferedReader name='/.../lib/python3.4/site-packages/mpl_toolkits/basemap/data/gshhs_c.dat'>
  self._readboundarydata('gshhs',as_polygons=False)
```

This seems to be the simplest way to accomplish this.   ResourceWarnings are most of the warning raised when running test.py on Python 3.x.