### PR TITLE
fix for DeprecationWarning: using a non-integer

### DIFF
--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -57,52 +57,52 @@ class TestShiftGrid(TestCase):
 
     def make_data_cyc(self):
         loncyc  =  np.array([0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300,\
-            330, 360], dtype=np.int)
+            330, 360],dtype=np.float)
         gridcyc = np.array([[0,  1,  2,  3,   4,   5,   6,   7,   8,   9,  10,\
-            11,   0]], dtype=np.int)
+            11,   0]],dtype=np.float)
         lonoutcyc  =  np.array([-180, -150, -120, -90, -60, -30, 0, 30,60,90,\
-            120, 150, 180], dtype=np.int)
+            120, 150, 180],dtype=np.float)
         gridoutcyc = np.array([[   6,    7,   8,    9,  10,  11, 0,  1,  2,3,\
-            4,   5,   6]], dtype=np.int)
+            4,   5,   6]],dtype=np.float)
         return loncyc, gridcyc, lonoutcyc, gridoutcyc
 
     def make_data_nocyc(self):
         lonnocyc  =  np.array([0, 30, 60, 90, 120, 150, 180, 210, 240, 270,\
-            300, 330], dtype=np.int)
+            300, 330],dtype=np.float)
         gridnocyc = np.array([[0,  1,  2,  3,   4,   5,   6,   7,   8,   9,\
-            10,  11]], dtype=np.int)
+            10,  11]],dtype=np.float)
         lonoutnocyc  =  np.array([-180, -150, -120, -90, -60, -30, 0, 30, 60,\
-            90, 120, 150], dtype=np.int)
+            90, 120, 150],dtype=np.float)
         gridoutnocyc = np.array([[   6,    7,   8,    9,  10,  11, 0,  1,  2,\
-            3,   4,   5]], dtype=np.int)
+            3,   4,   5]],dtype=np.float)
         return lonnocyc, gridnocyc, lonoutnocyc, gridoutnocyc
 
     def make_data_nocyc2(self):
         lonnocyc2  =  np.array([15, 45, 75, 105, 135, 165, 195, 225, 255, 285,\
-            315, 345], dtype=np.int)
+            315, 345],dtype=np.float)
         gridnocyc2 = np.array([[0,  1,  2,  3,   4,   5,   6,   7,   8,   9,\
-            10,  11]], dtype=np.int)
+            10,  11]],dtype=np.float)
         lonoutnocyc2  =  np.array([-165, -135, -105, -75, -45, -15, 15,45,75,\
-            105, 135, 165], dtype=np.int)
+            105, 135, 165],dtype=np.float)
         gridoutnocyc2 = np.array([[   6,    7,   8,    9,  10,  11, 0,  1,  2,\
-            3,   4,   5]], dtype=np.int)
+            3,   4,   5]],dtype=np.float)
         return lonnocyc2, gridnocyc2, lonoutnocyc2, gridoutnocyc2
 
     def test_cyc(self):
         lonin, gridin, lonout, gridout = self.make_data_cyc()
-        grid, lon = shiftgrid(lonin[len(lonin)/2], gridin, lonin, start=False)
+        grid, lon = shiftgrid(lonin[len(lonin)//2], gridin, lonin, start=False)
         assert (lon==lonout).all()
         assert (grid==gridout).all()
 
     def test_no_cyc(self):
         lonin, gridin, lonout, gridout = self.make_data_nocyc()
-        grid, lon = shiftgrid(lonin[len(lonin)/2], gridin, lonin, start=False)
+        grid, lon = shiftgrid(lonin[len(lonin)//2], gridin, lonin, start=False)
         assert (lon==lonout).all()
         assert (grid==gridout).all()
 
     def test_no_cyc2(self):
         lonin, gridin, lonout, gridout = self.make_data_nocyc2()
-        grid, lon = shiftgrid(lonin[len(lonin)/2], gridin, lonin, start=False)
+        grid, lon = shiftgrid(lonin[len(lonin)//2], gridin, lonin, start=False)
         assert (lon==lonout).all()
         assert (grid==gridout).all()
 
@@ -221,4 +221,3 @@ if __name__ == '__main__':
         print('{0}\n'.format(pkg_vers))
 
     unittest.main()
-

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -57,35 +57,35 @@ class TestShiftGrid(TestCase):
 
     def make_data_cyc(self):
         loncyc  =  np.array([0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300,\
-            330, 360],dtype=np.float)
+            330, 360], dtype=np.int)
         gridcyc = np.array([[0,  1,  2,  3,   4,   5,   6,   7,   8,   9,  10,\
-            11,   0]],dtype=np.float)
+            11,   0]], dtype=np.int)
         lonoutcyc  =  np.array([-180, -150, -120, -90, -60, -30, 0, 30,60,90,\
-            120, 150, 180],dtype=np.float)
+            120, 150, 180], dtype=np.int)
         gridoutcyc = np.array([[   6,    7,   8,    9,  10,  11, 0,  1,  2,3,\
-            4,   5,   6]],dtype=np.float)
+            4,   5,   6]], dtype=np.int)
         return loncyc, gridcyc, lonoutcyc, gridoutcyc
 
     def make_data_nocyc(self):
         lonnocyc  =  np.array([0, 30, 60, 90, 120, 150, 180, 210, 240, 270,\
-            300, 330],dtype=np.float)
+            300, 330], dtype=np.int)
         gridnocyc = np.array([[0,  1,  2,  3,   4,   5,   6,   7,   8,   9,\
-            10,  11]],dtype=np.float)
+            10,  11]], dtype=np.int)
         lonoutnocyc  =  np.array([-180, -150, -120, -90, -60, -30, 0, 30, 60,\
-            90, 120, 150],dtype=np.float)
+            90, 120, 150], dtype=np.int)
         gridoutnocyc = np.array([[   6,    7,   8,    9,  10,  11, 0,  1,  2,\
-            3,   4,   5]],dtype=np.float)
+            3,   4,   5]], dtype=np.int)
         return lonnocyc, gridnocyc, lonoutnocyc, gridoutnocyc
 
     def make_data_nocyc2(self):
         lonnocyc2  =  np.array([15, 45, 75, 105, 135, 165, 195, 225, 255, 285,\
-            315, 345],dtype=np.float)
+            315, 345], dtype=np.int)
         gridnocyc2 = np.array([[0,  1,  2,  3,   4,   5,   6,   7,   8,   9,\
-            10,  11]],dtype=np.float)
+            10,  11]], dtype=np.int)
         lonoutnocyc2  =  np.array([-165, -135, -105, -75, -45, -15, 15,45,75,\
-            105, 135, 165],dtype=np.float)
+            105, 135, 165], dtype=np.int)
         gridoutnocyc2 = np.array([[   6,    7,   8,    9,  10,  11, 0,  1,  2,\
-            3,   4,   5]],dtype=np.float)
+            3,   4,   5]], dtype=np.int)
         return lonnocyc2, gridnocyc2, lonoutnocyc2, gridoutnocyc2
 
     def test_cyc(self):


### PR DESCRIPTION
Fixes these deprecation warnings from unitest in the TestShiftGrid class:
> test_cyc (__main__.TestShiftGrid) ... lib/mpl_toolkits/basemap/test.py:93: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future

~~This was done by changing the numpy arrays datatype from float to int.~~