### PR TITLE
Correct Matplotlib documentation reference

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -3370,11 +3370,11 @@ class Basemap(object):
         As a result, those values will not be plotted.
 
         If ``tri`` is set to ``True``, an unstructured grid is assumed
-        (x,y,data must be 1-d) and matplotlib.pyplot.tricolor is used.
+        (x,y,data must be 1-d) and matplotlib.pyplot.tripcolor is used.
 
         Extra keyword ``ax`` can be used to override the default axis instance.
 
-        Other \**kwargs passed on to matplotlib.pyplot.pcolor (or tricolor if
+        Other \**kwargs passed on to matplotlib.pyplot.pcolor (or tripcolor if
         ``tri=True``).
 
         Note: (taken from matplotlib.pyplot.pcolor documentation)


### PR DESCRIPTION
The Basemap documentation for [pcolor](http://matplotlib.org/basemap/api/basemap_api.html#mpl_toolkits.basemap.Basemap.pcolor) refers to a Matplotlib function named tricolor. Such a function does not seem to exist; Matplotlib's [tripcolor](http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.tripcolor) should probably be referenced instead.

This pull request changes matplotlib.pyplot.tricolor to tripcolor in the Basemap documentation