### PR TITLE
Corrects the following error:

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4409,7 +4409,7 @@ f=image" %\
                          srs='EPSG:%s' % self.epsg, **kwargs)
         # return AxesImage instance.
         # this works for png and jpeg.
-        return self.imshow(imread(io.BytesIO(urllib2.urlopen(img.url).read()),
+        return self.imshow(imread(io.BytesIO(img.read()),
                            format=format),origin='upper')
         # this works for png, but not jpeg
         #return self.imshow(imread(urllib2.urlopen(img.url),format=format),origin='upper')


### PR DESCRIPTION
.7/site-packages/mpl_toolkits/basemap/__init__.py", line 4358, in wmsimage
    return self.imshow(imread(io.BytesIO(urllib2.urlopen(img.url).read()),
AttributeError: 'ResponseWrapper' object has no attribute 'url'

It might have something to do with an owslib update