### PR TITLE
fix #272

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4700,9 +4700,9 @@ f=image" %\
         returns a matplotlib.contour.ContourSet instance.
         """
         from .solar import daynight_grid
-        # make sure date is utc.
-        if date.utcoffset() is not None:
-            raise ValueError('datetime instance must be UTC')
+        # make sure date is UTC, or naive with repect to time zones
+        if date.utcoffset():
+            raise ValueError('datetime instance must be UTC, not {}'.format(date.tzname()))
         # create grid of day=0, night=1
         lons,lats,daynight = daynight_grid(date,delta,self.lonmin,self.lonmax)
         x,y = self(lons,lats)


### PR DESCRIPTION
Fixes problem with nightshade checking whether a datetime is in UTC; it was rejecting datetimes that have their `tzinfo` explicitly set to UTC. The check has now been corrected and simplified.

```python
In [37]: d = datetime.datetime.now()

In [38]: bool(d.utcoffset()) # time-zone naive
Out[38]: False

In [39]: d = d.replace(tzinfo=pytz.UTC)

In [40]: bool(d.utcoffset()) # utc
Out[41]: False

In [41]: eastern = pytz.timezone('US/Eastern')

In [42]: d = d.replace(tzinfo=eastern)

In [43]: bool(d.utcoffset()) # non-utc, non-zero offset
Out[43]: True
```

So therefore the check only needs to be `if date.utcoffset():`, which catches all non-zero offsets, and allows the naive case to continue passing.