### PR TITLE
Add diagnostics functions: proj4 ver. & Inv. Hammer

### DIFF
--- a/lib/mpl_toolkits/basemap/diagnostic.py
+++ b/lib/mpl_toolkits/basemap/diagnostic.py
@@ -2,6 +2,23 @@
 These are diagnostic and debugging functions for basemap.
 """
 
+def proj4_version():
+    """
+    Gives the proj.4 library's version number. (requires pyproj to be installed)
+
+    returns string, so proj.4 version 4.9.3 will return "4.9.3"
+    """
+    import pyproj
+    
+    # Get PROJ4 version in a floating point number
+    proj4_ver_num = pyproj.Proj(proj='latlong').proj_version
+    
+    # reformats floating point number into string (4.90 becomes '4.9.0')
+    # Exploits single number version numbers for proj4,
+    # This will need likely need to be change at some point as proj.4 version 4.10.0???
+    return '.'.join( str(int(proj4_ver_num*100)) )
+    
+    
 def package_versions():
     """
     Gives version information for dependent packages.
@@ -13,7 +30,7 @@ def package_versions():
 
     from matplotlib import __version__ as matplotlib_version
     from numpy import __version__ as numpy_version
-    import pyproj
+    from pyproj import __version__ as pyproj_version
     from shapefile import __version__ as pyshp_version
 
     import _geoslib
@@ -35,10 +52,6 @@ def package_versions():
         pil_version = 'not installed'
         pillow_version = 'not installed'
     
-    # Get PROJ.4 version info in a floating point number
-    proj_ver_num = pyproj.Proj(init='epsg:4326').proj_version
-    # reformats floating point number into string (4.90 becomes '4.9.0')
-    proj4_version = '.'.join(list(str(int(proj_ver_num*100))))
     
     BasemapPackageVersions = namedtuple(
                                'BasemapPackageVersions',
@@ -51,11 +64,44 @@ def package_versions():
                    basemap = basemap_version,
                    matplotlib = matplotlib_version,
                    numpy = numpy_version,
-                   pyproj = pyproj.__version__,
+                   pyproj = pyproj_version,
                    pyshp = pyshp_version,
-                   PROJ4 = proj4_version,
+                   PROJ4 = proj4_version(),
                    GEOS = _geoslib.__geos_version__,
                    # optional dependencies below
                    OWSLib = OWSLib_version,
                    PIL = pil_version,
                    Pillow = pillow_version)
+
+def check_proj_inv_hammer(segfault_protection_off=False):
+    """
+    Check if the inverse of the hammer projection is supported by installed
+    version of PROJ4.
+    
+    segfault_protection_off=True  - Turns off the protection from a segfault.
+                                     BE CAREFUL setting this to True.
+
+    returns True      - inverse hammer is supported
+            False     - inverse hammer is not supported
+            "Unknown" - support is Unknown
+    """
+    from distutils.version import LooseVersion
+    from pyproj import __version__ as pyproj_version
+    
+    if LooseVersion(proj4_version()) > LooseVersion('4.9.2'):
+        return True
+    
+    # pyproj_version_tup = version_str_to_tuple(pyproj_version)
+    if LooseVersion(pyproj_version) > LooseVersion('1.9.5.1') \
+            or segfault_protection_off is True:
+        from pyproj import Proj
+        hammer = Proj(proj='hammer')
+        
+        x, y = hammer(-30.0, 40.0)
+        try:
+            lon, lat = hammer(x, y, inverse=True)
+            return True
+        except RuntimeError:            
+            return False
+    
+    return 'Unknown'

--- a/lib/mpl_toolkits/basemap/diagnostic.py
+++ b/lib/mpl_toolkits/basemap/diagnostic.py
@@ -73,13 +73,15 @@ def package_versions():
                    PIL = pil_version,
                    Pillow = pillow_version)
 
-def check_proj_inv_hammer(segfault_protection_off=False):
+def check_proj_inv_hammer(segfault_protection=True):
     """
     Check if the inverse of the hammer projection is supported by installed
     version of PROJ4.
     
-    segfault_protection_off=True  - Turns off the protection from a segfault.
-                                     BE CAREFUL setting this to True.
+    segfault_protection   True (default) - test while protecting from segfault
+                          False -  testing that might cause Python to segfault.
+                                   BE CAREFUL setting this flag to False!
+                                   If it segfaults, this the inverse hammer is not supported.
 
     returns True      - inverse hammer is supported
             False     - inverse hammer is not supported
@@ -91,9 +93,8 @@ def check_proj_inv_hammer(segfault_protection_off=False):
     if LooseVersion(proj4_version()) > LooseVersion('4.9.2'):
         return True
     
-    # pyproj_version_tup = version_str_to_tuple(pyproj_version)
     if LooseVersion(pyproj_version) > LooseVersion('1.9.5.1') \
-            or segfault_protection_off is True:
+            or segfault_protection is False:
         from pyproj import Proj
         hammer = Proj(proj='hammer')
         


### PR DESCRIPTION
This is a refactor of the package_version function to move getting the proj4 version number into a new function, proj4_version.  check_proj_inv_hammer function is added for checking if the inverse of the hammer projection is available (which should be in the yet to be released proj.4 version 4.9.3).

check_proj_inv_hammer() and proj4_version() are intended to end up in setup.py, but may provide some use in the main basemap library.  Due to that reason, the imports are mostly self-contained for the function.

So, Proj.4 verion 4.9.3 has not been released, nor has the current development version of pyproj which has code that raises a RuntimeError when a projection's inverse function isn't available (pyproj 1.9.5.1 and before will segfault).  At the moment, I'm a little uncertain about putting these the check_proj_inv_hammer() into setup.py without one of the two libraries being released.  This effectively requires installation one of the development versions for the check_proj_inv_hammer function to pass the test, otherwise they risk a segfault.  This originates from discussion in PR #240.

Editing setup.py seems a little daunting because I'm a bit overwhelmed by what all setup.py can do/should do.  setup.py seems to work like a swiss army knife by doing a couple tasks well and other tasks not so well.

Here are my local test results of the functions, which where copied an pasted into ipython:
```Python
In [3]: proj4_version()
Out[3]: '4.9.2'

In [4]: package_versions()
Out[4]: BasemapPackageVersions(Python='2.7.4 (default, Apr  6 2013, 19:54:46) [M
SC v.1500 32 bit (Intel)]', basemap='1.0.8', matplotlib='1.5.1', numpy='1.10.4',
 pyproj='1.9.5.1', pyshp='1.2.3', PROJ4='4.9.2', GEOS='3.5.0-CAPI-1.9.0 r4084',
OWSLib='not installed', PIL='not installed', Pillow='not installed')

In [5]: check_proj_inv_hammer()
Out[5]: 'Unknown'

In [6]: check_proj_inv_hammer(True)
Out[6]: True
```