### PR TITLE
Avoid using deprecated get_axis_bgcolor() method with newer matplotlib

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -12,10 +12,12 @@ heavy lifting), and the following functions:
 
 :func:`addcyclic`: Add cyclic (wraparound) point in longitude.
 """
+from distutils.version import LooseVersion
 from matplotlib import __version__ as _matplotlib_version
 from matplotlib.cbook import is_scalar, dedent
 # check to make sure matplotlib is not too old.
-_mpl_required_version = '0.98'
+_matplotlib_version = LooseVersion(_matplotlib_version)
+_mpl_required_version = LooseVersion('0.98')
 if _matplotlib_version < _mpl_required_version:
     msg = dedent("""
     your matplotlib is too old - basemap requires version %s or
@@ -1649,7 +1651,10 @@ class Basemap(object):
         # if no fill_color given, use axes background color.
         # if fill_color is string 'none', really don't fill.
         if fill_color is None:
-            fill_color = ax.get_axis_bgcolor()
+            if _matplotlib_version >= '1.5':
+                fill_color = ax.get_facecolor()
+            else:
+                fill_color = ax.get_axis_bgcolor()
         elif fill_color == 'none' or fill_color == 'None':
             fill_color = None
         limb = None
@@ -1793,7 +1798,10 @@ class Basemap(object):
         # get current axes instance (if none specified).
         ax = ax or self._check_ax()
         # get axis background color.
-        axisbgc = ax.get_axis_bgcolor()
+        if _matplotlib_version >= '1.5':
+            axisbgc = ax.get_facecolor()
+        else:
+            axisbgc = ax.get_axis_bgcolor()
         npoly = 0
         polys = []
         for x,y in self.coastpolygons:

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -1651,7 +1651,7 @@ class Basemap(object):
         # if no fill_color given, use axes background color.
         # if fill_color is string 'none', really don't fill.
         if fill_color is None:
-            if _matplotlib_version >= '1.5':
+            if _matplotlib_version >= '2.0':
                 fill_color = ax.get_facecolor()
             else:
                 fill_color = ax.get_axis_bgcolor()


### PR DESCRIPTION
When plotting with newer versions of matplotlib, one gets a lot of deprecation warnings:
```
/rd22/scratch/broot/centos6/lib/python2.7/site-packages/mpl_toolkits/basemap/__init__.py:1652: MatplotlibDeprecationWarning: The get_axis_bgcolor function was deprecated in version 2.0. Use get_facecolor instead.
  fill_color = ax.get_axis_bgcolor()
/rd22/scratch/broot/centos6/lib/python2.7/site-packages/mpl_toolkits/basemap/__init__.py:1796: MatplotlibDeprecationWarning: The get_axis_bgcolor function was deprecated in version 2.0. Use get_facecolor instead.
  axisbgc = ax.get_axis_bgcolor()
/nas/home/broot/centos6/lib/python2.7/site-packages/matplotlib-1.5.1+1669.gbfe5e3f.dirty-py2.7-linux-x86_64.egg/matplotlib/cbook.py:137: MatplotlibDeprecationWarning: The axisbg attribute was deprecated in version 2.0. Use facecolor instead.
  warnings.warn(message, mplDeprecation, stacklevel=1)
```
This does a version check and uses the appropriate call instead. I think I found all instances of it.

There is still the annoying numpy warning, though:
```
/nas/home/broot/centos6/lib/python2.7/site-packages/numpy-1.12.0.dev0+e62aa19-py2.7-linux-x86_64.egg/numpy/ma/core.py:3192: FutureWarning: Currently, slicing will try to return a view of the data, but will return a copy of the mask. In the future, it will try to return both as views. This means that using `__setitem__` will propagate values back through all masks that are present.
  FutureWarning
/nas/home/broot/centos6/lib/python2.7/site-packages/numpy-1.12.0.dev0+e62aa19-py2.7-linux-x86_64.egg/numpy/ma/core.py:3113: FutureWarning: Currently, slicing will try to return a view of the data, but will return a copy of the mask. In the future, it will try to return both as views.
  FutureWarning
```