### PR TITLE
Fix print-command for python3

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4289,7 +4289,7 @@ format=png32&\
 f=image" %\
 (server,service,xmin,ymin,xmax,ymax,self.epsg,self.epsg,xpixels,ypixels,dpi)
         # print URL?
-        if verbose: print basemap_url
+        if verbose: print(basemap_url)
         # return AxesImage instance.
         return self.imshow(imread(urllib2.urlopen(basemap_url)),origin='upper')
 
@@ -4362,17 +4362,17 @@ f=image" %\
         # ypixels not given, find by scaling xpixels by the map aspect ratio.
         if ypixels is None:
             ypixels = int(self.aspect*xpixels)
-        if verbose: print server
+        if verbose: print(server)
         wms = WebMapService(server)
         if verbose:
-            print 'id: %s, version: %s' %\
-            (wms.identification.type,wms.identification.version)
-            print 'title: %s, abstract: %s' %\
-            (wms.identification.title,wms.identification.abstract)
-            print 'available layers:'
-            print list(wms.contents)
-            print 'projection options:'
-            print wms[kwargs['layers'][0]].crsOptions
+            print('id: %s, version: %s' %\
+            (wms.identification.type,wms.identification.version))
+            print('title: %s, abstract: %s' %\
+            (wms.identification.title,wms.identification.abstract))
+            print('available layers:')
+            print(list(wms.contents))
+            print('projection options:')
+            print(wms[kwargs['layers'][0]].crsOptions)
         # remove keys from kwargs that are over-ridden
         for k in ['format','bbox','service','size','srs']:
             if 'format' in kwargs: del kwargs['format']


### PR DESCRIPTION
The import does not work on python3 due to incompatible print commands in the init-file.

```python
>>> from mpl_toolkits.basemap import Basemap
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/uwe/rli-lokal/python_packages/basemap/lib/mpl_toolkits/basemap/__init__.py", line 4292
    if verbose: print basemap_url
                                ^
SyntaxError: Missing parentheses in call to 'print'
```

This PR just adds a few parenthesis to avoid these errors.