### PR TITLE
Reworded first line of docstring for quiver method

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -3702,6 +3702,7 @@ class Basemap(object):
     def quiver(self, x, y, u, v, *args, **kwargs):
         """
         Make a vector plot (u, v) with arrows on the map.
+
         Arguments may be 1-D or 2-D arrays or sequences
         (see matplotlib.pyplot.quiver documentation for details).
 

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -3702,8 +3702,8 @@ class Basemap(object):
     def quiver(self, x, y, u, v, *args, **kwargs):
         """
         Make a vector plot (u, v) with arrows on the map.
-        Grid must be evenly spaced regular grid in x and y.
-        (see matplotlib.pyplot.quiver documentation).
+        Arguments may be 1-D or 2-D arrays or sequences
+        (see matplotlib.pyplot.quiver documentation for details).
 
         If ``latlon`` keyword is set to True, x,y are intrepreted as
         longitude and latitude in degrees.  Data and longitudes are


### PR DESCRIPTION
The docstring for quiver that goes into the documentation is badly worded, making a borderline untrue statement that makes it seem like quiver only accepts 2-D data on a regular grid (when 1-D data at random points in X and Y is actually fine).

This is a draft attempt to address issue #326 .
