### PR TITLE
Convert hold-related functions to attribute assignments.

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -3225,16 +3225,16 @@ class Basemap(object):
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             ret =  ax.scatter(*args, **kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3263,16 +3263,16 @@ class Basemap(object):
         """
         ax = kwargs.pop('ax', None) or self._check_ax()
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             ret =  ax.plot(*args, **kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # set axes limits to fit map region.
         self.set_axes_limits(ax=ax)
         # clip to map limbs
@@ -3299,16 +3299,16 @@ class Basemap(object):
         if 'origin' not in kwargs:
             kwargs['origin']='lower'
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             ret =  ax.imshow(*args, **kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3349,10 +3349,10 @@ class Basemap(object):
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             if kwargs.pop('tri', False):
                 try:
@@ -3386,9 +3386,9 @@ class Basemap(object):
                 y = ma.masked_values(np.where(y > 1.e20,1.e20,y), 1.e20)
                 ret = ax.pcolor(x,y,data,**kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3424,16 +3424,16 @@ class Basemap(object):
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             ret =  ax.pcolormesh(x,y,data,**kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3470,10 +3470,10 @@ class Basemap(object):
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             # make x,y masked arrays
             # (masked where data is outside of projection limb)
@@ -3481,9 +3481,9 @@ class Basemap(object):
             y = ma.masked_values(np.where(y > 1.e20,1.e20,y), 1.e20)
             ret = ax.hexbin(x,y,**kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3516,10 +3516,10 @@ class Basemap(object):
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             if kwargs.pop('tri', False):
                 try:
@@ -3581,9 +3581,9 @@ class Basemap(object):
                 data = ma.masked_array(data,mask=mask)
                 CS = ax.contour(x,y,data,*args,**kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # reset current active image (only if pyplot is imported).
         if plt and CS.get_array() is not None:
             plt.sci(CS)
@@ -3619,10 +3619,10 @@ class Basemap(object):
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             if kwargs.get('tri', False):
                 try:
@@ -3686,9 +3686,9 @@ class Basemap(object):
                 data = ma.masked_array(data,mask=mask)
                 CS = ax.contourf(x,y,data,*args,**kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # reset current active image (only if pyplot is imported).
         if plt and CS.get_array() is not None:
             plt.sci(CS)
@@ -3718,16 +3718,16 @@ class Basemap(object):
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             ret =  ax.quiver(x,y,u,v,*args,**kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         if plt is not None and ret.get_array() is not None:
             plt.sci(ret)
         # set axes limits to fit map region.
@@ -3760,16 +3760,16 @@ class Basemap(object):
             raise NotImplementedError(msg)
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         try:
             ret =  ax.streamplot(x,y,u,v,*args,**kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         if plt is not None and ret.lines.get_array() is not None:
             plt.sci(ret.lines)
         # set axes limits to fit map region.
@@ -3810,10 +3810,10 @@ class Basemap(object):
             raise NotImplementedError(msg)
         ax, plt = self._ax_plt_from_kw(kwargs)
         # allow callers to override the hold state by passing hold=True|False
-        b = ax.ishold()
+        b = ax._hold
         h = kwargs.pop('hold',None)
         if h is not None:
-            ax.hold(h)
+            ax._hold = h
         lons, lats = self(x, y, inverse=True)
         unh = ma.masked_where(lats <= 0, u)
         vnh = ma.masked_where(lats <= 0, v)
@@ -3824,9 +3824,9 @@ class Basemap(object):
             kwargs['flip_barb']=True
             retsh =  ax.barbs(x,y,ush,vsh,*args,**kwargs)
         except:
-            ax.hold(b)
+            ax._hold = b
             raise
-        ax.hold(b)
+        ax._hold = b
         # Because there are two collections returned in general,
         # we can't set the current image...
         #if plt is not None and ret.get_array() is not None:

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -3206,6 +3206,17 @@ class Basemap(object):
             import matplotlib.pyplot as plt
             plt.draw_if_interactive()
 
+
+    def _save_use_hold(self, ax, kwargs):
+        h = kwargs.pop('hold', None)
+        if hasattr(ax, '_hold'):
+            self._tmp_hold = ax._hold
+            ax._hold = h
+
+    def _restore_hold(self, ax):
+        if hasattr(ax, '_hold'):
+            ax._hold = self._tmp_hold
+
     @_transform1d
     def scatter(self, *args, **kwargs):
         """
@@ -3224,17 +3235,11 @@ class Basemap(object):
         Other \**kwargs passed on to matplotlib.pyplot.scatter.
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             ret =  ax.scatter(*args, **kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3262,17 +3267,11 @@ class Basemap(object):
         Other \**kwargs passed on to matplotlib.pyplot.plot.
         """
         ax = kwargs.pop('ax', None) or self._check_ax()
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             ret =  ax.plot(*args, **kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # set axes limits to fit map region.
         self.set_axes_limits(ax=ax)
         # clip to map limbs
@@ -3298,17 +3297,11 @@ class Basemap(object):
         # use origin='lower', unless overridden.
         if 'origin' not in kwargs:
             kwargs['origin']='lower'
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             ret =  ax.imshow(*args, **kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3348,11 +3341,7 @@ class Basemap(object):
         if the dimensions are the same, then the last row and column of data will be ignored.
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             if kwargs.pop('tri', False):
                 try:
@@ -3385,10 +3374,8 @@ class Basemap(object):
                 x = ma.masked_values(np.where(x > 1.e20,1.e20,x), 1.e20)
                 y = ma.masked_values(np.where(y > 1.e20,1.e20,y), 1.e20)
                 ret = ax.pcolor(x,y,data,**kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3423,17 +3410,11 @@ class Basemap(object):
         if the dimensions are the same, then the last row and column of data will be ignored.
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             ret =  ax.pcolormesh(x,y,data,**kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3469,21 +3450,15 @@ class Basemap(object):
         Other \**kwargs passed on to matplotlib.pyplot.hexbin
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             # make x,y masked arrays
             # (masked where data is outside of projection limb)
             x = ma.masked_values(np.where(x > 1.e20,1.e20,x), 1.e20)
             y = ma.masked_values(np.where(y > 1.e20,1.e20,y), 1.e20)
             ret = ax.hexbin(x,y,**kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # reset current active image (only if pyplot is imported).
         if plt:
             plt.sci(ret)
@@ -3515,11 +3490,7 @@ class Basemap(object):
         (or tricontour if ``tri=True``).
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             if kwargs.pop('tri', False):
                 try:
@@ -3580,10 +3551,8 @@ class Basemap(object):
                 mask = np.logical_or(ma.getmaskarray(data),xymask)
                 data = ma.masked_array(data,mask=mask)
                 CS = ax.contour(x,y,data,*args,**kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # reset current active image (only if pyplot is imported).
         if plt and CS.get_array() is not None:
             plt.sci(CS)
@@ -3618,11 +3587,7 @@ class Basemap(object):
         (or tricontourf if ``tri=True``).
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             if kwargs.get('tri', False):
                 try:
@@ -3685,10 +3650,8 @@ class Basemap(object):
                 mask = np.logical_or(ma.getmaskarray(data),xymask)
                 data = ma.masked_array(data,mask=mask)
                 CS = ax.contourf(x,y,data,*args,**kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # reset current active image (only if pyplot is imported).
         if plt and CS.get_array() is not None:
             plt.sci(CS)
@@ -3717,17 +3680,11 @@ class Basemap(object):
         Other \*args and \**kwargs passed on to matplotlib.pyplot.quiver.
         """
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             ret =  ax.quiver(x,y,u,v,*args,**kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         if plt is not None and ret.get_array() is not None:
             plt.sci(ret)
         # set axes limits to fit map region.
@@ -3759,17 +3716,11 @@ class Basemap(object):
             you have %s""" % _matplotlib_version)
             raise NotImplementedError(msg)
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
+        self._save_use_hold(ax, kwargs)
         try:
             ret =  ax.streamplot(x,y,u,v,*args,**kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         if plt is not None and ret.lines.get_array() is not None:
             plt.sci(ret.lines)
         # set axes limits to fit map region.
@@ -3809,24 +3760,18 @@ class Basemap(object):
             you have %s""" % _matplotlib_version)
             raise NotImplementedError(msg)
         ax, plt = self._ax_plt_from_kw(kwargs)
-        # allow callers to override the hold state by passing hold=True|False
-        b = ax._hold
-        h = kwargs.pop('hold',None)
-        if h is not None:
-            ax._hold = h
         lons, lats = self(x, y, inverse=True)
         unh = ma.masked_where(lats <= 0, u)
         vnh = ma.masked_where(lats <= 0, v)
         ush = ma.masked_where(lats > 0, u)
         vsh = ma.masked_where(lats > 0, v)
+        self._save_use_hold(ax, kwargs)
         try:
             retnh =  ax.barbs(x,y,unh,vnh,*args,**kwargs)
             kwargs['flip_barb']=True
             retsh =  ax.barbs(x,y,ush,vsh,*args,**kwargs)
-        except:
-            ax._hold = b
-            raise
-        ax._hold = b
+        finally:
+            self._restore_hold(ax)
         # Because there are two collections returned in general,
         # we can't set the current image...
         #if plt is not None and ret.get_array() is not None:


### PR DESCRIPTION
This is a minimal change so that the deprecation of "hold"
in mpl 2.x won't trigger warnings in Basemap from routine
plotting calls.