### PR TITLE
Shiftdata fix

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4811,13 +4811,7 @@ f=image" %\
                         datain_save[:,1:] = datain
                         datain_save[:,0] = datain[:,-1]
                         datain = datain_save
-                # mask points outside
-                # map region so they don't wrap back in the domain.
-                mask = np.logical_or(lonsin<lon_0-180,lonsin>lon_0+180)
-                lonsin = np.where(mask,1.e30,lonsin)
-                if datain is not None and mask.any():
-                    # superimpose on existing mask
-                    datain = ma.masked_where(mask, datain)
+
         # 1-d data.
         elif lonsin.ndim == 1:
             nlons = len(lonsin)
@@ -4856,12 +4850,15 @@ f=image" %\
                         datain_save[1:] = datain
                         datain_save[0] = datain[-1]
                         datain = datain_save
-                # mask points outside
-                # map region so they don't wrap back in the domain.
-                mask = np.logical_or(lonsin<lon_0-180,lonsin>lon_0+180)
-                lonsin = np.where(mask,1.e30,lonsin)
-                if datain is not None and mask.any():
-                    datain = ma.masked_where(mask, datain)
+
+        # mask points outside
+        # map region so they don't wrap back in the domain.
+        mask = np.logical_or(lonsin<lon_0-180,lonsin>lon_0+180)
+        lonsin = np.where(mask,1.e30,lonsin)
+        if datain is not None and mask.any():
+            datain = ma.masked_where(mask, datain)
+
+
         if datain is not None:
             return lonsin, datain
         else:

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -3702,6 +3702,7 @@ class Basemap(object):
     def quiver(self, x, y, u, v, *args, **kwargs):
         """
         Make a vector plot (u, v) with arrows on the map.
+
         Arguments may be 1-D or 2-D arrays or sequences
         (see matplotlib.pyplot.quiver documentation for details).
 

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -3702,8 +3702,8 @@ class Basemap(object):
     def quiver(self, x, y, u, v, *args, **kwargs):
         """
         Make a vector plot (u, v) with arrows on the map.
-        Grid must be evenly spaced regular grid in x and y.
-        (see matplotlib.pyplot.quiver documentation).
+        Arguments may be 1-D or 2-D arrays or sequences
+        (see matplotlib.pyplot.quiver documentation for details).
 
         If ``latlon`` keyword is set to True, x,y are intrepreted as
         longitude and latitude in degrees.  Data and longitudes are

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4749,11 +4749,11 @@ f=image" %\
                          given by current map projection.
         fix_wrap_around  if True reindex (if required) longitudes (and data) to
                          avoid jumps caused by remapping of longitudes of
-                         points from outside of the (lon_0-180, lon_0+180)
+                         points from outside of the [lon_0-180, lon_0+180]
                          interval back into the interval.
                          If False do not reindex longitudes and data, but do
                          make sure that longitudes are in the
-                         (lon_0-180, lon_0+180) range.
+                         [lon_0-180, lon_0+180] range.
         ==============   ====================================================
 
         if datain given, returns ``dataout,lonsout`` (data and longitudes shifted to fit in interval

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4747,10 +4747,13 @@ f=image" %\
         datain           original 1-d or 2-d data. Default None.
         lon_0            center of map projection region. Defaut None,
                          given by current map projection.
-        fix_wrap_around  if True try to shift longitudes (and data) to correctly
-                         display the array in the selected projection. If False
-                         do not attempt the longitudes or data fix for the
-                         wrap-around.
+        fix_wrap_around  if True reindex (if required) longitudes (and data) to
+                         avoid jumps caused by remapping of longitudes of
+                         points from outside of the (lon_0-180, lon_0+180)
+                         interval back into the interval.
+                         If False do not reindex longitudes and data, but do
+                         make sure that longitudes are in the
+                         (lon_0-180, lon_0+180) range.
         ==============   ====================================================
 
         if datain given, returns ``dataout,lonsout`` (data and longitudes shifted to fit in interval

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4792,7 +4792,7 @@ f=image" %\
 
             # if no shift necessary, itemindex will be
             # empty, so don't do anything
-            if itemindex and fix_wrap_around:
+            if fix_wrap_around and itemindex:
                 # check to see if cyclic (wraparound) point included
                 # if so, remove it.
                 if np.abs(lonsin1[0]-lonsin1[-1]) < 1.e-4:
@@ -4834,7 +4834,7 @@ f=image" %\
             else:
                 itemindex = 0
 
-            if itemindex and fix_wrap_around:
+            if fix_wrap_around and itemindex:
                 # check to see if cyclic (wraparound) point included
                 # if so, remove it.
                 if np.abs(lonsin[0]-lonsin[-1]) < 1.e-4:

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -526,7 +526,8 @@ def _transform(plotfunc):
             # shift data to map projection region for
             # cylindrical and pseudo-cylindrical projections.
             if self.projection in _cylproj or self.projection in _pseudocyl:
-                x, data = self.shiftdata(x, data)
+                x, data = self.shiftdata(x, data,
+                                         fix_wrap_around=plotfunc.__name__ not in ["scatter"])
             # convert lat/lon coords to map projection coords.
             x, y = self(x,y)
         return plotfunc(self,x,y,data,*args,**kwargs)
@@ -544,7 +545,7 @@ def _transform1d(plotfunc):
             # cylindrical and pseudo-cylindrical projections.
             if self.projection in _cylproj or self.projection in _pseudocyl:
                 if x.ndim == 1:
-                    x = self.shiftdata(x)
+                    x = self.shiftdata(x, fix_wrap_around=plotfunc.__name__ not in ["scatter"])
                 elif x.ndim == 0:
                     if x > 180:
                         x = x - 360.
@@ -4723,7 +4724,7 @@ f=image" %\
                 _ax = plt.gca()
         return _ax, plt
 
-    def shiftdata(self,lonsin,datain=None,lon_0=None):
+    def shiftdata(self,lonsin,datain=None,lon_0=None,fix_wrap_around=True):
         """
         Shift longitudes (and optionally data) so that they match map projection region.
         Only valid for cylindrical/pseudo-cylindrical global projections and data
@@ -4746,6 +4747,10 @@ f=image" %\
         datain           original 1-d or 2-d data. Default None.
         lon_0            center of map projection region. Defaut None,
                          given by current map projection.
+        fix_wrap_around  if True try to shift longitudes (and data) to correctly
+                         display the array in the selected projection. If False
+                         do not attempt the longitudes or data fix for the
+                         wrap-around.
         ==============   ====================================================
 
         if datain given, returns ``dataout,lonsout`` (data and longitudes shifted to fit in interval
@@ -4784,7 +4789,7 @@ f=image" %\
 
             # if no shift necessary, itemindex will be
             # empty, so don't do anything
-            if itemindex:
+            if itemindex and fix_wrap_around:
                 # check to see if cyclic (wraparound) point included
                 # if so, remove it.
                 if np.abs(lonsin1[0]-lonsin1[-1]) < 1.e-4:
@@ -4826,7 +4831,7 @@ f=image" %\
             else:
                 itemindex = 0
 
-            if itemindex:
+            if itemindex and fix_wrap_around:
                 # check to see if cyclic (wraparound) point included
                 # if so, remove it.
                 if np.abs(lonsin[0]-lonsin[-1]) < 1.e-4:
@@ -4857,7 +4862,6 @@ f=image" %\
         lonsin = np.where(mask,1.e30,lonsin)
         if datain is not None and mask.any():
             datain = ma.masked_where(mask, datain)
-
 
         if datain is not None:
             return lonsin, datain

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -125,7 +125,7 @@ class TestShiftdata(TestCase):
         lons = [179, 180, 180, 0, 290, 10, 320, -150, 350, -250, 250]
         bm = Basemap(lon_0=0)
 
-        # before having several break points would cause the exception,
+        # before, having several break points would cause the exception,
         # inside the shiftdata method called from scatter method.
         self.assertRaises(ValueError, bm.shiftdata, lons, fix_wrap_around=True)
 

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -133,8 +133,8 @@ class TestShiftdata(TestCase):
 
         # Check if the modified longitudes are inside of the projection region
         for lon in lons_new:
-            assert lon >= bm.projparms["lon_0"] - 180
-            assert lon <= bm.projparms["lon_0"] + 180
+            assert lon >= bm.projparams["lon_0"] - 180
+            assert lon <= bm.projparams["lon_0"] + 180
 
 
 

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -38,7 +38,7 @@ class TestRotateVector(TestCase):
     def test_nan(self):
         B = Basemap()
         u,v,lat,lon=self.make_array()
-        # Set one element to 0, so that the vector magnitude is 0. 
+        # Set one element to 0, so that the vector magnitude is 0.
         u[1,1] = 0.
         ru, rv = B.rotate_vector(u,v, lon, lat)
         assert not np.isnan(ru).any()
@@ -117,6 +117,27 @@ class TestShiftdata(TestCase):
         lats = [10, ] * len(lons1d)
         return np.meshgrid(lons1d, lats)[0]
 
+    def test_non_monotonous_longitudes(self):
+        """
+        when called for scatter, the longitudes passed to shiftdata are
+        not necessarily monotonous...
+        """
+        lons = [179, 180, 180, 0, 290, 10, 320, -150, 350, -250, 250]
+        bm = Basemap(lon_0=0)
+
+        # before having several break points would cause the exception,
+        # inside the shiftdata method called from scatter method.
+        self.assertRaises(ValueError, bm.shiftdata, lons, fix_wrap_around=True)
+
+        lons_new = bm.shiftdata(lons, fix_wrap_around=False)
+
+        # Check if the modified longitudes are inside of the projection region
+        for lon in lons_new:
+            assert lon >= bm.projparms["lon_0"] - 180
+            assert lon <= bm.projparms["lon_0"] + 180
+
+
+
     def test_2_points_should_work(self):
         """
         Shiftdata should work with 2 points
@@ -160,7 +181,7 @@ class TestShiftdata(TestCase):
         lonsout = bm.shiftdata(lonsin[:, :2])
         assert_almost_equal(lonsout_expected, lonsout)
 
-@skipIf(PY3 and LooseVersion(pyproj.__version__) <= LooseVersion("1.9.4"), 
+@skipIf(PY3 and LooseVersion(pyproj.__version__) <= LooseVersion("1.9.4"),
         "Test skipped in Python 3.x with pyproj version 1.9.4 and below.")
 class TestProjectCoords(TestCase):
     def get_data(self):
@@ -224,7 +245,7 @@ if __name__ == '__main__':
     import unittest
 
     from mpl_toolkits.basemap.diagnostic import package_versions
-    
+
     if '--verbose' in sys.argv or '-v' in sys.argv:
         pkg_vers = package_versions()
         print('Basemaps installed package versions:')

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -137,6 +137,21 @@ class TestShiftdata(TestCase):
             assert lon <= bm.projparams["lon_0"] + 180
 
 
+    def test_shiftdata_on_monotonous_lons(self):
+        """
+        Test that shiftdata with fix_wrap_around keyword added works as before,
+        when it is True
+        """
+
+        bm = Basemap(lon_0=0)
+
+        lons_in = [120, 140, 160, 180, 200, 220]
+        lons_out_expect = [-160, -140,  120,  140,  160,  180]
+        lons_out = bm.shiftdata(lons_in, fix_wrap_around=True)
+
+        assert_almost_equal(lons_out, lons_out_expect)
+
+
 
     def test_2_points_should_work(self):
         """


### PR DESCRIPTION
I've tried to avoid the portion of shiftdata trying to do the wraparound fix for the scatter. For this I've added a keyword argument to the shiftdata and then execute the wraparound fix only if the argument is True. It is True by default but is set to Falsewhen the plotfunc is scatter.

That should close the #197, but to be sure I would like to wait for the failing example from @kiwi937.


Refactor: move masking of the output longitudes and data arrays for 1d and 2d cases to a single place, since they are the same.

Cheers