### PR TITLE
Fix AttributeError: module 'matplotlib.colors' has no attribute 'normalize'

### DIFF
--- a/examples/plotmap_masked.py
+++ b/examples/plotmap_masked.py
@@ -40,7 +40,7 @@ topodatm = ma.masked_values(topodat, 1.e10)
 palette = plt.cm.YlOrRd
 palette.set_bad('aqua', 1.0)
 # plot image over map with imshow.
-im = m.imshow(topodatm,palette,norm=colors.normalize(vmin=0.0,vmax=3000.0,clip=False))
+im = m.imshow(topodatm,palette,norm=colors.Normalize(vmin=0.0,vmax=3000.0,clip=False))
 m.colorbar(im,pad='12%') # draw colorbar
 # plot blue dot on boulder, colorado and label it as such.
 xpt,ypt = m(-104.237,40.125) 


### PR DESCRIPTION
Using matplotlib 2.0:
```
Running plotmap_masked.py
Traceback (most recent call last):
  File "D:\Build\basemap\basemap-git\examples\plotmap_masked.py", line 43, in <module>
    im = m.imshow(topodatm,palette,norm=colors.normalize(vmin=0.0,vmax=3000.0,clip=False))
AttributeError: module 'matplotlib.colors' has no attribute 'normalize'
TEST FAILURE (status=1)
```

See also http://matplotlib.org/api/colors_api.html#matplotlib.colors.Normalize