### PR TITLE
Fix DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future

### DIFF
--- a/examples/streamplot_demo.py
+++ b/examples/streamplot_demo.py
@@ -15,7 +15,7 @@ udat = ncfile.variables['sfc_u'][0,:,:]
 vdat = ncfile.variables['sfc_v'][0,:,:]
 lons1 = ncfile.variables['longitude'][:]
 lats1 = ncfile.variables['latitude'][:]
-lat0 = lats1[len(lats1)/2]; lon0 = lons1[len(lons1)/2]
+lat0 = lats1[len(lats1)//2]; lon0 = lons1[len(lons1)//2]
 lons, lats = np.meshgrid(lons1,lats1)
 ncfile.close()
 


### PR DESCRIPTION
```
Running streamplot_demo.py
D:\Build\basemap\basemap-git\examples\streamplot_demo.py:18: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  lat0 = lats1[len(lats1)/2]; lon0 = lons1[len(lons1)/2]
```