### PR TITLE
Add rather than nest include arrays for geos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ set GEOS_DIR to /usr/local), or edit the setup.py script
 manually and set the variable GEOS_dir (right after the line
 that says "set GEOS_dir manually here".""" % "', '".join(geos_search_locations))
 else:
-    geos_include_dirs=[os.path.join(GEOS_dir,'include'),inc_dirs]
+    geos_include_dirs=[os.path.join(GEOS_dir,'include')] + inc_dirs
     geos_library_dirs=[os.path.join(GEOS_dir,'lib'),os.path.join(GEOS_dir,'lib64')]
 
 packages          = ['mpl_toolkits','mpl_toolkits.basemap']


### PR DESCRIPTION
Shouldn't the contents of inc_dirs be added to geos_include_dirs rather than nested within it?

When I run "python3 setup.py build", building _geoslib.c fails as one of the -I flags is
`-I['/.../lib/python3.4/site-packages/numpy/core/include'] `

I got the same for `python3 -m pip install --upgrade -e 'git+https://github.com/matplotlib/basemap.git#egg=basemap'` but it seems an editable install is not possible because of how mpl_toolkits.axes_grid1 is imported.