### PR TITLE
Fix MatplotlibDeprecationWarning for axesPatch in Matplotlib 2.1.0

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -1701,10 +1701,10 @@ class Basemap(object):
                 if zorder is not None:
                     spine.set_zorder(zorder)
             if self.projection not in ['geos','ortho','nsper']:
-                limb = ax.axesPatch
+                limb = ax.patch
 
         if limb is not None:
-            if limb is not ax.axesPatch:
+            if limb is not ax.patch:
                 ax.add_patch(limb)
             self._mapboundarydrawn = limb
             if fill_color is None:


### PR DESCRIPTION
With the release of Matplotlib 2.1.0, Axes.axesPatch has been deprecated in favor of Axes.patch. Changes made are to `basemap/__init__.py`.

Specific error: 

> MatplotlibDeprecationWarning: The axesPatch function was deprecated in version 2.1. Use Axes.patch instead.