### PR TITLE
Transparency support

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4243,6 +4243,7 @@ imageSR=%s&\
 size=%s,%s&\
 dpi=%s&\
 format=png32&\
+transparent=true&\
 f=image" %\
 (server,service,xmin,ymin,xmax,ymax,self.epsg,self.epsg,xpixels,ypixels,dpi)
         # print URL?


### PR DESCRIPTION
Without this some tiles cannot be used correctly (e.g.  https://services.arcgisonline.com/arcgis/rest/services/Reference/World_Boundaries_and_Places_Alternate/MapServer/tile/1/0/0.png)