### PR TITLE
mention pillow when PIL is not found (instead of linking to long-dead PIL page)

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4020,7 +4020,9 @@ class Basemap(object):
             try:
                 import Image
             except ImportError:
-                raise ImportError('warpimage method requires PIL (http://www.pythonware.com/products/pil)')
+                msg = ('warpimage method requires PIL '
+                       '(http://pillow.readthedocs.io)')
+                raise ImportError(msg)
 
         from matplotlib.image import pil_to_array
         if self.celestial:


### PR DESCRIPTION
I think instead of advertising the long-stale PIL page the import error should directly point towards pillow.

see also #177 