### PR TITLE
Add installation instructions for pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ prompt.
 To run all the examples (except those that have extra dependencies
 or require an internet connection), execute 'python run_all.py'.
 
+An alternative method is using `pip`:
+
+```
+pip install git+https://github.com/matplotlib/basemap.git
+```
+
+You migh want to run pip with administrative privilegies (e.g. `sudo pip`) or
+perform an user only installation (e.g. `pip install --user`).
+
 ## Contact
 
 Ben Root <ben.v.root@gmail.com>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Plot on map projections (with coastlines and political boundaries)
 using matplotlib.
 
+**Warning**: this package is being deprecated in favour of
+[cartopy](https://scitools.org.uk/cartopy/docs/latest/).
+
 ## Requirements
 
 * Python 2.6 (or higher)

--- a/README.md
+++ b/README.md
@@ -103,11 +103,8 @@ or require an internet connection), execute 'python run_all.py'.
 An alternative method is using `pip`:
 
 ```
-pip install git+https://github.com/matplotlib/basemap.git
+pip install --user git+https://github.com/matplotlib/basemap.git
 ```
-
-You migh want to run pip with administrative privilegies (e.g. `sudo pip`) or
-perform an user only installation (e.g. `pip install --user`).
 
 ## Contact
 


### PR DESCRIPTION
Several issues report problems with using `pip install basemap`. A workaround is using the latest version from Github.

Some issues with pip problems: #405 #403 #198 #251 