### PR TITLE
Fix arcgisimage for cylindrical coordinates, remove imread 

### DIFF
--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4228,6 +4228,21 @@ class Basemap(object):
 
         returns a matplotlib.image.AxesImage instance.
         """
+
+
+        # fix PIL import on some versions of OSX and scipy
+        try:
+            from PIL import Image
+        except ImportError:
+            try:
+                import Image
+            except ImportError:
+                msg = ('warpimage method requires PIL '
+                       '(http://pillow.readthedocs.io)')
+                raise ImportError(msg)
+
+
+
         if not hasattr(self,'epsg'):
             msg = dedent("""
             Basemap instance must be creating using an EPSG code
@@ -4247,7 +4262,7 @@ class Basemap(object):
                 arcgisimage cannot handle images that cross
                 the dateline for cylindrical projections.""")
                 raise ValueError(msg)
-        if self.projection == 'cyl':
+        if self.projection != 'cyl':
             xmin = (180./np.pi)*xmin; xmax = (180./np.pi)*xmax
             ymin = (180./np.pi)*ymin; ymax = (180./np.pi)*ymax
         # ypixels not given, find by scaling xpixels by the map aspect ratio.
@@ -4268,8 +4283,8 @@ f=image" %\
         # print URL?
         if verbose: print(basemap_url)
         # return AxesImage instance.
-        return self.imshow(imread(urlopen(basemap_url)),ax=ax,
-                           origin='upper')
+        img = Image.open(urlopen(basemap_url))
+        return self.imshow(img, ax=ax, origin='upper')
 
     def wmsimage(self,server,\
                  xpixels=400,ypixels=None,\

--- a/lib/mpl_toolkits/basemap/__init__.py
+++ b/lib/mpl_toolkits/basemap/__init__.py
@@ -4237,7 +4237,7 @@ class Basemap(object):
             try:
                 import Image
             except ImportError:
-                msg = ('warpimage method requires PIL '
+                msg = ('arcgisimage method requires PIL '
                        '(http://pillow.readthedocs.io)')
                 raise ImportError(msg)
 

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -249,6 +249,7 @@ class TestOrthoProjPolygons(TestCase):
             m = Basemap(projection='ortho',resolution=r,lat_1=45.,lat_2=55,lat_0=50,lon_0=-107.)
         pass
 
+@skipIf(not PY3, "Test skipped for Python 2.x as it requires PIL installed")
 class TestArcgisimage(TestCase):
 	def test_cyl_proj_should_not_fail(self):
 		m = Basemap(projection='cyl',

--- a/lib/mpl_toolkits/basemap/test.py
+++ b/lib/mpl_toolkits/basemap/test.py
@@ -244,10 +244,19 @@ class TestInputValidation(TestCase):
 
 class TestOrthoProjPolygons(TestCase):
     def test_basemapcreation_should_not_fail(self):
-        # different resolutions should work 
+        # different resolutions should work
         for r in ['c', 'l', 'i', 'h', 'f']:
             m = Basemap(projection='ortho',resolution=r,lat_1=45.,lat_2=55,lat_0=50,lon_0=-107.)
         pass
+
+class TestArcgisimage(TestCase):
+	def test_cyl_proj_should_not_fail(self):
+		m = Basemap(projection='cyl',
+					llcrnrlon=-90,llcrnrlat=30,
+					urcrnrlon=-60,urcrnrlat=60)
+		m.arcgisimage(verbose=True)
+
+
 
 def test():
     """


### PR DESCRIPTION

## Change summary
* Fix projection of domain corner for cyl projections.
* Remove reference to `matplotlib.image.imread` as it is not able to open URLs anymore.
* Add a test to make sure arcgisimage method works.

## Objective

This PR makes the following code not fail and show a map:

```python
from mpl_toolkits.basemap import Basemap
import matplotlib.pyplot as plt

m = Basemap(projection='cyl',llcrnrlon=-90,llcrnrlat=30,urcrnrlon=-60,urcrnrlat=60, epsg="4326")
m.arcgisimage(verbose=True)
plt.show()
```

## Current behavior

The code above produces the exception below with current basemap:

```
---------------------------------------------------------------------------
UnsupportedOperation                      Traceback (most recent call last)
<ipython-input-1-18c43d1bdc96> in <module>
      8 m = Basemap(projection='cyl',llcrnrlon=-90,llcrnrlat=30,urcrnrlon=-60,urcrnrlat=60, epsg="4326")
      9 
---> 10 m.arcgisimage(verbose=True)
     11 

~/Python/anaconda3/envs/py373/lib/python3.7/site-packages/mpl_toolkits/basemap/__init__.py in arcgisimage(self, server, service, xpixels, ypixels, dpi, verbose, **kwargs)
   4271         if verbose: print(basemap_url)
   4272         # return AxesImage instance.
-> 4273         return self.imshow(imread(urlopen(basemap_url)),ax=ax,
   4274                            origin='upper')
   4275 

~/Python/anaconda3/envs/py373/lib/python3.7/site-packages/matplotlib/image.py in imread(fname, format)
   1474             with urllib.request.urlopen(fname) as response:
   1475                 return imread(response, format=ext)
-> 1476     with img_open(fname) as image:
   1477         return (_pil_png_to_float_array(image)
   1478                 if isinstance(image, PIL.PngImagePlugin.PngImageFile) else

~/Python/anaconda3/envs/py373/lib/python3.7/site-packages/PIL/ImageFile.py in __init__(self, fp, filename)
    115         try:
    116             try:
--> 117                 self._open()
    118             except (
    119                 IndexError,  # end of data

~/Python/anaconda3/envs/py373/lib/python3.7/site-packages/PIL/PngImagePlugin.py in _open(self)
    651             # get next chunk
    652 
--> 653             cid, pos, length = self.png.read()
    654 
    655             try:

~/Python/anaconda3/envs/py373/lib/python3.7/site-packages/PIL/PngImagePlugin.py in read(self)
    126             s = self.fp.read(8)
    127             cid = s[4:]
--> 128             pos = self.fp.tell()
    129             length = i32(s)
    130 

UnsupportedOperation: seek

```

