### PR TITLE
Fix broken documentation link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ## Documentation
 
-See http://matplotlib.github.com/basemap/
+See http://matplotlib.github.io/basemap/
 
 See scripts in `examples` directory for example usage.
 


### PR DESCRIPTION
The link provided on the README was dead, giving me a 404. Using `github.io`, I believe it now directs to the intended location.