### PR TITLE
Fix broken Basemap.arcgisimage method

### DIFF
--- a/packages/basemap/src/mpl_toolkits/basemap/__init__.py
+++ b/packages/basemap/src/mpl_toolkits/basemap/__init__.py
@@ -4284,9 +4284,6 @@ class Basemap(object):
                 arcgisimage cannot handle images that cross
                 the dateline for cylindrical projections.""")
                 raise ValueError(msg)
-        if self.projection != 'cyl':
-            xmin = (180./np.pi)*xmin; xmax = (180./np.pi)*xmax
-            ymin = (180./np.pi)*ymin; ymax = (180./np.pi)*ymax
         # ypixels not given, find by scaling xpixels by the map aspect ratio.
         if ypixels is None:
             ypixels = int(self.aspect*xpixels)

--- a/packages/basemap/src/mpl_toolkits/basemap/__init__.py
+++ b/packages/basemap/src/mpl_toolkits/basemap/__init__.py
@@ -4215,7 +4215,7 @@ class Basemap(object):
         return im
 
     def arcgisimage(self,server='http://server.arcgisonline.com/ArcGIS',\
-                 service='ESRI_Imagery_World_2D',xpixels=400,ypixels=None,\
+                 service='World_Imagery',xpixels=400,ypixels=None,\
                  dpi=96,verbose=False,**kwargs):
         """
         Retrieve an image using the ArcGIS Server REST API and display it on
@@ -4232,7 +4232,7 @@ class Basemap(object):
         server           web map server URL (default
                          http://server.arcgisonline.com/ArcGIS).
         service          service (image type) hosted on server (default
-                         ESRI_Imagery_World_2D, which is NASA 'Blue Marble'
+                         'World_Imagery', which is NASA 'Blue Marble'
                          image).
         xpixels          requested number of image pixels in x-direction
                          (default 400).


### PR DESCRIPTION
Solves #546 by changing the default ArcGIS service from "ESRI_Imagery_World_2D" to "World_Imagery" and removing a conversion block that was destroying the projection coordinates for all projections except for "cyl".