### PR TITLE
Update manylinux action to compile NumPy on Py38/Py39 x86

### DIFF
--- a/.github/workflows/basemap-for-manylinux.yml
+++ b/.github/workflows/basemap-for-manylinux.yml
@@ -264,7 +264,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y gcc g++ make
-          pip install "numpy < 1.21.5"
+          pip install "numpy < 1.24"
         if: matrix.arch == 'x86' && (matrix.python-version >= '3.8' || matrix.python-version >= '3.10')
       -
         name: Install package

--- a/.github/workflows/basemap-for-manylinux.yml
+++ b/.github/workflows/basemap-for-manylinux.yml
@@ -265,7 +265,7 @@ jobs:
           apt-get update
           apt-get install -y gcc g++ make
           pip install "numpy < 1.21.5"
-        if: matrix.arch == 'x86' && matrix.python-version == '3.10'
+        if: matrix.arch == 'x86' && (matrix.python-version >= '3.8' || matrix.python-version >= '3.10')
       -
         name: Install package
         run: |


### PR DESCRIPTION
Fixes broken CI on manylinux x86 for Python 3.8 and Python 3.9 due to lack of wheels in PyPI.