### PR TITLE
Upgrade bundled GEOS to 3.6.5

### DIFF
--- a/.github/workflows/basemap-for-manylinux.yml
+++ b/.github/workflows/basemap-for-manylinux.yml
@@ -112,7 +112,7 @@ jobs:
         name: Build GEOS from source
         run: |
           cd ${{ env.PKGDIR }}
-          python -c "import utils; utils.GeosLibrary('3.5.1').build('extern', njobs=16)"
+          python -c "import utils; utils.GeosLibrary('3.6.5').build('extern', njobs=16)"
       -
         name: Upload GEOS artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -85,23 +85,10 @@ jobs:
   build-geos:
     strategy:
       matrix:
-        include:
-          -
-            arch: "x64"
-            msvc-toolset: "14.16"
-            cmake-version: "3.14.7"
-          -
-            arch: "x86"
-            msvc-toolset: "14.16"
-            cmake-version: "3.14.7"
-          -
-            arch: "x64"
-            msvc-toolset: "9.0"
-            cmake-version: "3.14.7"
-          -
-            arch: "x86"
-            msvc-toolset: "9.0"
-            cmake-version: "3.14.7"
+        arch:
+          ["x64", "x86"]
+        msvc-toolset:
+          ["9.0", "14.16"]
       max-parallel: 4
       fail-fast: false
     needs: lint
@@ -123,7 +110,7 @@ jobs:
         name: Set CMake
         uses: jwlawson/actions-setup-cmake@v1.9
         with:
-          cmake-version: ${{ matrix.cmake-version }}
+          cmake-version: "3.14.7"
       -
         name: Set Python
         uses: actions/setup-python@v2

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -134,7 +134,7 @@ jobs:
         name: Build GEOS from source
         run: |
           cd ${{ env.PKGDIR }}
-          python -c "import utils; utils.GeosLibrary('3.5.1').build('extern', njobs=16)"
+          python -c "import utils; utils.GeosLibrary('3.6.5').build('extern', njobs=16)"
       -
         name: Upload GEOS artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -86,22 +86,22 @@ jobs:
     strategy:
       matrix:
         include:
-          - 
+          -
             arch: "x64"
             msvc-toolset: "14.16"
             cmake-version: "3.14.7"
-          - 
+          -
             arch: "x86"
             msvc-toolset: "14.16"
-            cmake-version: "3.13.2"
-          - 
+            cmake-version: "3.14.7"
+          -
             arch: "x64"
             msvc-toolset: "9.0"
             cmake-version: "3.14.7"
-          - 
+          -
             arch: "x86"
             msvc-toolset: "9.0"
-            cmake-version: "3.13.2"
+            cmake-version: "3.14.7"
       max-parallel: 4
       fail-fast: false
     needs: lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Added
+- Optional argument `encoding_errors` for `Basemap.readshapefile` method
+  (PR [#554] by @guziy, implements request [#552]).
+
 ### Changed
-- Upgrade default GEOS library dependency to 3.6.5.
+- Upgrade bundled GEOS library to 3.6.5.
 
 ## [1.3.4] - 2022-08-10
 
@@ -929,6 +933,10 @@ https://semver.org/spec/v2.0.0.html
 - Fix glitches in drawing of parallels and meridians.
 
 
+[#554]:
+https://github.com/matplotlib/basemap/pull/554
+[#552]:
+https://github.com/matplotlib/basemap/issues/552
 [#548]:
 https://github.com/matplotlib/basemap/pull/548
 [#547]:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Changed
+- Upgrade default GEOS library dependency to 3.6.5.
+
 ## [1.3.4] - 2022-08-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Otherwise, you will need to install `basemap` from source as follows:
    use the helper provided in `utils`, i.e.
    ```sh
    export GEOS_DIR=<your desired location>
-   python -c "import utils; utils.GeosLibrary('3.5.1').build(installdir='${GEOS_DIR}')"
+   python -c "import utils; utils.GeosLibrary('3.6.5').build(installdir='${GEOS_DIR}')"
    ```
    or you can link directly to the system library if it is already
    installed. `GEOS_DIR` must point to the GEOS installation prefix;

--- a/packages/basemap/utils/GeosLibrary.py
+++ b/packages/basemap/utils/GeosLibrary.py
@@ -166,6 +166,11 @@ class GeosLibrary(object):
                     for line in lines:
                         fd.write(line.replace(oldtext, newtext).encode())
 
+        # Apply specific patches for 3.6.0 <= GEOS < 3.7.0 on Windows.
+        if (3, 6, 0) <= self.version_tuple < (3, 7, 0) and os.name == "nt":
+            autogen_file = os.path.join(zipfold, "autogen.bat")
+            subprocess.call([autogen_file], cwd=zipfold)
+
     def build(self, installdir=None, njobs=1):
         """Build and install GEOS from source."""
 

--- a/packages/basemap/utils/GeosLibrary.py
+++ b/packages/basemap/utils/GeosLibrary.py
@@ -127,8 +127,7 @@ class GeosLibrary(object):
         if os.path.exists(zipfold):
             if not overwrite:
                 raise OSError("folder '{0}' already exists".format(zipfold))
-            else:
-                shutil.rmtree(zipfold)
+            shutil.rmtree(zipfold)
 
         # Decompress zip file.
         with contextlib.closing(ZipFile(zippath, "r")) as fd:

--- a/packages/basemap/utils/GeosLibrary.py
+++ b/packages/basemap/utils/GeosLibrary.py
@@ -20,6 +20,7 @@
 
 import io
 import os
+import sys
 import ssl
 import glob
 import shutil
@@ -170,6 +171,22 @@ class GeosLibrary(object):
         if (3, 6, 0) <= self.version_tuple < (3, 7, 0) and os.name == "nt":
             autogen_file = os.path.join(zipfold, "autogen.bat")
             subprocess.call([autogen_file], cwd=zipfold)
+            cppfile = os.path.join(zipfold, "src", "geomgraph", "DirectedEdgeStar.cpp")
+            with io.open(cppfile, "r", encoding="utf-8") as fd:
+                lines = fd.readlines()
+            with io.open(cppfile, "wb") as fd:
+                oldtext = "DirectedEdgeStar::print() const"
+                newtext = oldtext.replace(" const", "")
+                for line in lines:
+                    fd.write(line.replace(oldtext, newtext).encode())
+            hfile = os.path.join(zipfold, "include", "geos", "geomgraph", "DirectedEdgeStar.h")
+            with io.open(hfile, "r", encoding="utf-8") as fd:
+                lines = fd.readlines()
+            with io.open(hfile, "wb") as fd:
+                oldtext = "virtual std::string print() const;"
+                newtext = oldtext.replace(" const", "")
+                for line in lines:
+                    fd.write(line.replace(oldtext, newtext).encode())
 
     def build(self, installdir=None, njobs=1):
         """Build and install GEOS from source."""
@@ -186,29 +203,29 @@ class GeosLibrary(object):
             installdir = os.path.expanduser("~/.local/share/libgeos")
         installdir = os.path.abspath(installdir)
 
-        # Define configure options.
+        # Define generic configure and build options.
         config_opts = [
             "-DCMAKE_INSTALL_PREFIX={0}".format(installdir),
             "-DGEOS_ENABLE_TESTS=OFF",
             "-DCMAKE_BUILD_TYPE=Release",
         ]
-        if os.name == "nt" and self.version_tuple < (3, 6, 0):
-            config_opts = ["-G", "NMake Makefiles"] + config_opts
-
-        # Define build options.
         build_env = os.environ.copy()
         build_opts = [
             "--config", "Release",
             "--target", "install",
         ]
+
+        # Define custom configure and build options.
         if os.name != "nt":
             build_env["MAKEFLAGS"] = "-j {0:d}".format(njobs)
-        elif self.version_tuple < (3, 6, 0):
+        elif self.version_tuple < (3, 6, 0) or sys.version_info < (3, 3):
             win64 = (8 * struct.calcsize("P") == 64)
+            config_opts = ["-G", "NMake Makefiles"] + config_opts
             build_opts.extend([
                 "--",
                 "WIN64={0}".format("YES" if win64 else "NO"),
                 "BUILD_BATCH={0}".format("YES" if njobs > 1 else "NO"),
+                "MSVC_VER=1400",
             ])
         else:
             build_opts = ["-j", "{0:d}".format(njobs)] + build_opts


### PR DESCRIPTION
This pull request fixes the `GeosLibrary` helper class to be able to build GEOS 3.6.5 on Windows and thus be able to bundle GEOS 3.6.5 on all the precompiled binary wheels.