### PR TITLE
Upgrade GitHub workflows to use Node 16

### DIFF
--- a/.github/workflows/basemap-data-hires.yml
+++ b/.github/workflows/basemap-data-hires.yml
@@ -2,6 +2,7 @@ name: basemap-data-hires
 
 env:
   PKGDIR: "packages/basemap_data_hires"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 on:
   push:

--- a/.github/workflows/basemap-data-hires.yml
+++ b/.github/workflows/basemap-data-hires.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Upload checkout
         uses: actions/upload-artifact@v1

--- a/.github/workflows/basemap-data-hires.yml
+++ b/.github/workflows/basemap-data-hires.yml
@@ -2,6 +2,7 @@ name: basemap-data-hires
 
 env:
   PKGDIR: "packages/basemap_data_hires"
+  PYTHONWARNINGS: "ignore:DEPRECATION"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 on:

--- a/.github/workflows/basemap-data.yml
+++ b/.github/workflows/basemap-data.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Upload checkout
         uses: actions/upload-artifact@v1

--- a/.github/workflows/basemap-data.yml
+++ b/.github/workflows/basemap-data.yml
@@ -2,6 +2,7 @@ name: basemap-data
 
 env:
   PKGDIR: "packages/basemap_data"
+  PYTHONWARNINGS: "ignore:DEPRECATION"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 on:

--- a/.github/workflows/basemap-data.yml
+++ b/.github/workflows/basemap-data.yml
@@ -2,6 +2,7 @@ name: basemap-data
 
 env:
   PKGDIR: "packages/basemap_data"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 on:
   push:

--- a/.github/workflows/basemap-for-manylinux.yml
+++ b/.github/workflows/basemap-for-manylinux.yml
@@ -2,6 +2,7 @@ name: basemap-for-manylinux
 
 env:
   PKGDIR: "packages/basemap"
+  PYTHONWARNINGS: "ignore:DEPRECATION"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 on:

--- a/.github/workflows/basemap-for-manylinux.yml
+++ b/.github/workflows/basemap-for-manylinux.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Upload checkout
         uses: actions/upload-artifact@v1

--- a/.github/workflows/basemap-for-manylinux.yml
+++ b/.github/workflows/basemap-for-manylinux.yml
@@ -2,6 +2,7 @@ name: basemap-for-manylinux
 
 env:
   PKGDIR: "packages/basemap"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 on:
   push:

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -2,6 +2,7 @@ name: basemap-for-windows
 
 env:
   PKGDIR: "packages/basemap"
+  PYTHONWARNINGS: "ignore:DEPRECATION"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 on:

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -110,7 +110,7 @@ jobs:
           version: ${{ matrix.msvc-toolset }}
       -
         name: Set CMake
-        uses: jwlawson/actions-setup-cmake@v1.9
+        uses: jwlawson/actions-setup-cmake@v1.13
         with:
           cmake-version: "3.14.7"
       -

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Upload checkout
         uses: actions/upload-artifact@v1

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -48,7 +48,7 @@ jobs:
           path: .
       -
         name: Set Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           architecture: ${{ matrix.arch }}
           python-version: ${{ matrix.python-version }}
@@ -114,7 +114,7 @@ jobs:
           cmake-version: "3.14.7"
       -
         name: Set Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           architecture: ${{ matrix.arch }}
           python-version: "3.6"
@@ -164,7 +164,7 @@ jobs:
           version: ${{ env.msvc-toolset }}
       -
         name: Set Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           architecture: ${{ matrix.arch }}
           python-version: ${{ matrix.python-version }}
@@ -217,7 +217,7 @@ jobs:
     steps:
       -
         name: Set Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           architecture: ${{ matrix.arch }}
           python-version: ${{ matrix.python-version }}
@@ -252,7 +252,7 @@ jobs:
     steps:
       -
         name: Set Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           architecture: ${{ matrix.arch }}
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -2,6 +2,7 @@ name: basemap-for-windows
 
 env:
   PKGDIR: "packages/basemap"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 on:
   push:


### PR DESCRIPTION
This pull request updates the actions required by the `basemap` workflows to versions that use Node 16.