### PR TITLE
Ensure that Windows Python3 wheels are built with MSVC 14.0 

### DIFF
--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -90,7 +90,7 @@ jobs:
         arch:
           ["x64", "x86"]
         msvc-toolset:
-          ["9.0", "14.16"]
+          ["9.0", "14.0"]
       max-parallel: 4
       fail-fast: false
     needs: lint
@@ -155,7 +155,7 @@ jobs:
           if ("${{ matrix.python-version }}" -eq "2.7") {
               echo "msvc-toolset=9.0" >> $env:GITHUB_ENV
           } else {
-              echo "msvc-toolset=14.16" >> $env:GITHUB_ENV
+              echo "msvc-toolset=14.0" >> $env:GITHUB_ENV
           }
       -
         name: Set MSVC toolset

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -19,7 +19,7 @@ on:
 jobs:
 
   checkout:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       -
         name: Checkout
@@ -32,7 +32,7 @@ jobs:
           path: .
 
   lint:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         python-version:
@@ -94,7 +94,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
     needs: lint
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       -
         name: Download checkout
@@ -141,7 +141,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
     needs: build-geos
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       -
         name: Download checkout
@@ -214,7 +214,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       -
         name: Set Python
@@ -248,7 +248,7 @@ jobs:
       max-parallel: 1
     if: startsWith(github.event.ref, 'refs/tags/v')
     needs: test
-    runs-on: windows-latest
+    runs-on: windows-2019
     environment: PyPI
     steps:
       -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ https://semver.org/spec/v2.0.0.html
 - Upgrade `matplotlib` upper pin to 3.7.
 - Upgrade `pyproj` upper pin to 3.5.
 
+### Fixed
+- Set MSVC 14.0 (VS2015) to build the precompiled Windows wheels in
+  GitHub workflows.
+
 ## [1.3.5] - 2022-10-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ https://semver.org/spec/v2.0.0.html
 
 ## [1.3.6]
 
+### Added
+- Optional argument `toolset` in `GeosLibrary.build` method.
+
 ### Changed
 - Upgrade `matplotlib` upper pin to 3.7.
 - Upgrade `pyproj` upper pin to 3.5.

--- a/packages/basemap/utils/GeosLibrary.py
+++ b/packages/basemap/utils/GeosLibrary.py
@@ -242,7 +242,7 @@ class GeosLibrary(object):
 
         # Define custom configure and build options.
         if os.name == "nt":
-            config_opts += ["-DCMAKE_CXX_FLAGS='/wd4251 /wd4458 /wd4530'"]
+            config_opts += ["-DCMAKE_CXX_FLAGS='/wd4251 /wd4458 /wd4530 /EHsc'"]
             if version >= (3, 6, 0) and sys.version_info[:2] >= (3, 3):
                 build_opts = ["-j", "{0:d}".format(njobs)] + build_opts
             else:

--- a/packages/basemap/utils/GeosLibrary.py
+++ b/packages/basemap/utils/GeosLibrary.py
@@ -213,7 +213,7 @@ class GeosLibrary(object):
                     line = line.replace(oldtext2, newtext2)
                     fd.write(line.encode())
 
-    def build(self, installdir=None, njobs=1):
+    def build(self, installdir=None, toolset=None, njobs=1):
         """Build and install GEOS from source."""
 
         # Download and extract zip file if not present.
@@ -244,6 +244,8 @@ class GeosLibrary(object):
         if os.name == "nt":
             config_opts += ["-DCMAKE_CXX_FLAGS='/wd4251 /wd4458 /wd4530 /EHsc'"]
             if version >= (3, 6, 0) and sys.version_info[:2] >= (3, 3):
+                if toolset is not None:
+                    config_opts += ["-DCMAKE_GENERATOR_TOOLSET={0}".format(toolset)]
                 build_opts = ["-j", "{0:d}".format(njobs)] + build_opts
             else:
                 win64 = (8 * struct.calcsize("P") == 64)


### PR DESCRIPTION
This PR updates the GitHub workflow `basemap-for-windows` to ensure that GEOS and `_geoslib` are built using MSVC 14.0 for backwards compatibility.

In addition, `GeosLibrary.build` now receives an optional argument `toolset`, so that e.g. Windows users with Visual Studio 2022 can set `toolset=v140` and build with MSVC 14.0 if they have the VS2015 subpackage available.