### PR TITLE
Ensure that _geoslib is built with MSVC 14.0 for Windows Python3

### DIFF
--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -157,20 +157,6 @@ jobs:
           name: checkout
           path: .
       -
-        name: Set MSVC toolset version
-        run: |
-          if ("${{ matrix.python-version }}" -eq "2.7") {
-              echo "msvc-toolset=9.0" >> $env:GITHUB_ENV
-          } else {
-              echo "msvc-toolset=14.0" >> $env:GITHUB_ENV
-          }
-      -
-        name: Set MSVC toolset
-        uses: pylegacy/actions/setup-msvc@v1
-        with:
-          architecture: ${{ matrix.arch }}
-          version: ${{ env.msvc-toolset }}
-      -
         name: Set Python
         uses: actions/setup-python@v4
         with:
@@ -191,6 +177,20 @@ jobs:
           }
           $env:SETUPTOOLS_USE_DISTUTILS = "stdlib"
           python -m pip install "numpy == ${pkgvers}"
+      -
+        name: Set MSVC toolset version
+        run: |
+          if ("${{ matrix.python-version }}" -eq "2.7") {
+              echo "msvc-toolset=9.0" >> $env:GITHUB_ENV
+          } else {
+              echo "msvc-toolset=14.0" >> $env:GITHUB_ENV
+          }
+      -
+        name: Set MSVC toolset
+        uses: pylegacy/actions/setup-msvc@v1
+        with:
+          architecture: ${{ matrix.arch }}
+          version: ${{ env.msvc-toolset }}
       -
         name: Download GEOS artifacts
         uses: actions/download-artifact@v1

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -93,6 +93,11 @@ jobs:
           ["x64", "x86"]
         msvc-toolset:
           ["9.0", "14.0"]
+        include:
+          - msvc-toolset: "9.0"
+            python-version: "2.7"
+          - msvc-toolset: "14.0"
+            python-version: "3.5"
       max-parallel: 4
       fail-fast: false
     needs: lint
@@ -120,7 +125,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           architecture: ${{ matrix.arch }}
-          python-version: "3.6"
+          python-version: ${{ matrix.python-version }}
       -
         name: Build GEOS from source
         run: |

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -111,10 +111,10 @@ jobs:
           path: .
       -
         name: Set MSVC toolset
-        uses: pylegacy/actions/setup-msvc@v1
+        uses: pylegacy/actions/setup-msvc@v2
         with:
-          architecture: ${{ matrix.arch }}
-          version: ${{ matrix.msvc-toolset }}
+          arch: ${{ matrix.arch }}
+          toolset: ${{ matrix.msvc-toolset }}
       -
         name: Set CMake
         uses: jwlawson/actions-setup-cmake@v1.13
@@ -187,10 +187,10 @@ jobs:
           }
       -
         name: Set MSVC toolset
-        uses: pylegacy/actions/setup-msvc@v1
+        uses: pylegacy/actions/setup-msvc@v2
         with:
-          architecture: ${{ matrix.arch }}
-          version: ${{ env.msvc-toolset }}
+          arch: ${{ matrix.arch }}
+          toolset: ${{ env.msvc-toolset }}
       -
         name: Download GEOS artifacts
         uses: actions/download-artifact@v1

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -119,7 +119,7 @@ jobs:
         name: Set CMake
         uses: jwlawson/actions-setup-cmake@v1.13
         with:
-          cmake-version: "3.14.7"
+          cmake-version: "3.24.2"
       -
         name: Set Python
         uses: actions/setup-python@v4

--- a/.github/workflows/basemap-for-windows.yml
+++ b/.github/workflows/basemap-for-windows.yml
@@ -130,7 +130,7 @@ jobs:
         name: Build GEOS from source
         run: |
           cd ${{ env.PKGDIR }}
-          python -c "import utils; utils.GeosLibrary('3.6.5').build('extern', njobs=16)"
+          python -c "import utils; utils.GeosLibrary('3.6.5').build('extern', toolset='${{ matrix.msvc-toolset }}', njobs=16)"
       -
         name: Upload GEOS artifacts
         uses: actions/upload-artifact@v1

--- a/packages/basemap/utils/GeosLibrary.py
+++ b/packages/basemap/utils/GeosLibrary.py
@@ -242,13 +242,17 @@ class GeosLibrary(object):
 
         # Define custom configure and build options.
         if os.name == "nt":
+            win64 = (8 * struct.calcsize("P") == 64)
             config_opts += ["-DCMAKE_CXX_FLAGS='/wd4251 /wd4458 /wd4530 /EHsc'"]
             if version >= (3, 6, 0) and sys.version_info[:2] >= (3, 3):
                 if toolset is not None:
-                    config_opts += ["-DCMAKE_GENERATOR_TOOLSET={0}".format(toolset)]
+                    try:
+                        msvc = "v{0:d}".format(int(float(toolset) * 10))
+                    except (TypeError, ValueError):
+                        msvc = toolset
+                    config_opts += ["-DCMAKE_GENERATOR_TOOLSET={0}".format(msvc)]
                 build_opts = ["-j", "{0:d}".format(njobs)] + build_opts
             else:
-                win64 = (8 * struct.calcsize("P") == 64)
                 config_opts = ["-G", "NMake Makefiles"] + config_opts
                 build_opts.extend([
                     "--",

--- a/packages/basemap/utils/GeosLibrary.py
+++ b/packages/basemap/utils/GeosLibrary.py
@@ -243,7 +243,7 @@ class GeosLibrary(object):
         # Define custom configure and build options.
         if os.name == "nt":
             win64 = (8 * struct.calcsize("P") == 64)
-            config_opts += ["-DCMAKE_CXX_FLAGS='/wd4251 /wd4458 /wd4530 /EHsc'"]
+            config_opts += ["-DCMAKE_CXX_FLAGS='/wd4251 /wd4355 /wd4458 /wd4530 /EHsc'"]
             if version >= (3, 6, 0) and sys.version_info[:2] >= (3, 3):
                 config_opts = ["-A", "x64" if win64 else "Win32"] + config_opts
                 if toolset is not None:

--- a/packages/basemap/utils/GeosLibrary.py
+++ b/packages/basemap/utils/GeosLibrary.py
@@ -245,6 +245,7 @@ class GeosLibrary(object):
             win64 = (8 * struct.calcsize("P") == 64)
             config_opts += ["-DCMAKE_CXX_FLAGS='/wd4251 /wd4458 /wd4530 /EHsc'"]
             if version >= (3, 6, 0) and sys.version_info[:2] >= (3, 3):
+                config_opts = ["-A", "x64" if win64 else "Win32"] + config_opts
                 if toolset is not None:
                     try:
                         msvc = "v{0:d}".format(int(float(toolset) * 10))


### PR DESCRIPTION
In the hotfix release 1.3.6 of `basemap`, this problem was first addressed, and after that it was possible to build `geos_c.dll` with MSVC 14.0 for Python 3 on Windows. However, the `_geoslib` module was still being built with MSVC 19.33 because of some limitation in the GitHub Action used to setup MSVC. Furthermore, the solution in 1.3.6 is not enough in case we are trying to build GEOS >= 3.6 using the `GeosLibrary` helper class.

This PR addresses these remaining problems and ensures that the GitHub workflows build binaries linked with MSVC 14.0 for Python 3 on Windows. 