### PR TITLE
Fix AttributeError with Pillow >= 10.0

### DIFF
--- a/packages/basemap/src/mpl_toolkits/basemap/__init__.py
+++ b/packages/basemap/src/mpl_toolkits/basemap/__init__.py
@@ -4075,7 +4075,7 @@ class Basemap(object):
                 w, h = pilImage.size
                 width = int(np.round(w*scale))
                 height = int(np.round(h*scale))
-                pilImage = pilImage.resize((width,height),Image.ANTIALIAS)
+                pilImage = pilImage.resize((width,height),Image.LANCZOS)
             # orientation of arrays returned by pil_to_array changed in
             # matplotlib 1.2 (https://github.com/matplotlib/matplotlib/pull/616)
             self._bm_rgba = pil_to_array(pilImage)[::-1,:]


### PR DESCRIPTION
The deprecated `Image.ANTIALIAS` constant was removed in Pillow 10.0. See https://pillow.readthedocs.io/en/stable/deprecations.html#constants