### PR TITLE
Support Cython 3.0

### DIFF
--- a/.github/workflows/basemap-for-manylinux.yml
+++ b/.github/workflows/basemap-for-manylinux.yml
@@ -187,7 +187,7 @@ jobs:
           export NUMPY_INCLUDE_PATH=${sitepkgdir}/numpy/core/include
           if [ "${{ matrix.python-version }}" = "3.11" ]; then
               kwds="--no-build-isolation"
-              pip install setuptools wheel "cython >= 0.29, < 3.0"
+              pip install setuptools wheel "cython >= 0.29, < 3.1"
           fi
           cd ${{ env.PKGDIR }}
           python setup.py sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ https://semver.org/spec/v2.0.0.html
 
 ### Changed
 - Upgrade bundled GEOS library to 3.6.5.
+- Update build dependencies:
+  - Upgrade `Cython` upper pin to 3.1.
 
 ### Fixed
 - Set MSVC 14.0 (VS2015) to build the `_geoslib` module in the
   precompiled Windows wheels (PR [#565]).
 - Reimplement `matplotlib` version checks without using `distutils` and
   remove old switches related to unsupported `matplotlib` versions.
+- Fix `_geoslib.pyx` compilation with Cython 3.0+ using the compiler
+  directive "legacy_implicit_noexcept" (PR [#593] by @musicinmybrain).
 
 ### Removed
 - Attribute `__version__` in `basemap.proj` module.
@@ -999,6 +1003,8 @@ https://semver.org/spec/v2.0.0.html
 - Fix glitches in drawing of parallels and meridians.
 
 
+[#593]:
+https://github.com/matplotlib/basemap/pull/593
 [#583]:
 https://github.com/matplotlib/basemap/issues/583
 [#582]:

--- a/packages/basemap/pyproject.toml
+++ b/packages/basemap/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     'numpy == 1.16.6; sys_platform != "darwin" and (python_version >= "3.7" and python_version <= "3.9")',
     'numpy == 1.16.6; python_version == "2.7" or (python_version >= "3.4" and python_version <= "3.6")',
     'numpy == 1.11.3; python_version == "2.6" or (python_version >= "3.2" and python_version <= "3.3")',
-    'cython >= 0.29, < 3.0; python_version >= "3.3" or python_version < "3.0"',
+    'cython >= 0.29, < 3.1; python_version >= "3.3" or python_version < "3.0"',
     'cython >= 0.26, < 0.27; python_version == "3.2"'
 ]
 build-backend = "setuptools.build_meta"

--- a/packages/basemap/requirements-setup.txt
+++ b/packages/basemap/requirements-setup.txt
@@ -1,6 +1,2 @@
-cython >= 0.29, < 3.0; python_version == "2.6"
-cython >= 0.29, < 3.0; python_version == "2.7"
+cython >= 0.29, < 3.1; python_version >= "3.3" or python_version < "3.0"
 cython >= 0.26, < 0.27; python_version == "3.2"
-cython >= 0.29, < 3.0; python_version == "3.3"
-cython >= 0.29, < 3.0; python_version == "3.4"
-cython >= 0.29, < 3.1; python_version >= "3.5"

--- a/packages/basemap/requirements-setup.txt
+++ b/packages/basemap/requirements-setup.txt
@@ -1,4 +1,6 @@
 cython >= 0.29, < 3.0; python_version == "2.6"
 cython >= 0.29, < 3.0; python_version == "2.7"
 cython >= 0.26, < 0.27; python_version == "3.2"
-cython >= 0.29, < 3.0; python_version >= "3.3"
+cython >= 0.29, < 3.0; python_version == "3.3"
+cython >= 0.29, < 3.0; python_version == "3.4"
+cython >= 0.29, < 3.1; python_version >= "3.5"

--- a/packages/basemap/setup.py
+++ b/packages/basemap/setup.py
@@ -15,6 +15,12 @@ from setuptools.command.sdist import sdist
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
 
+try:
+    import Cython
+    cython_major_version = int(Cython.__version__.split(".")[0])
+except ImportError:
+    cython_major_version = 0
+
 
 def get_content(name, splitlines=False):
     """Return the file contents with project root as root folder."""
@@ -157,7 +163,8 @@ ext_modules = [
 for ext in ext_modules:
     ext.cython_directives = [
         ("language_level", str(sys.version_info[0])),
-    ]
+        ("legacy_implicit_noexcept", True),
+    ][:1 + int(cython_major_version >= 3)]
 
 # Define all the different requirements.
 setup_requires = get_content("requirements-setup.txt", splitlines=True)

--- a/packages/basemap/src/_geoslib.pyx
+++ b/packages/basemap/src/_geoslib.pyx
@@ -51,7 +51,7 @@ cdef extern from "geos_c.h":
         pass
     ctypedef struct GEOSCoordSeq:
         pass
-    ctypedef void (*GEOSMessageHandler)(char *fmt, char *list)
+    ctypedef void (*GEOSMessageHandler)(char *fmt, char *list) noexcept
     char *GEOSversion()
     void initGEOS(GEOSMessageHandler notice_function, GEOSMessageHandler error_function)
     void finishGEOS()
@@ -105,7 +105,7 @@ cdef extern from "geos_c.h":
     GEOSCoordSeq  *GEOSGeom_getCoordSeq(GEOSGeom* g)
     int GEOSCoordSeq_getSize(GEOSCoordSeq *s, unsigned int *size)
 
-cdef void notice_h(char *fmt, char*msg):
+cdef void notice_h(char *fmt, char*msg) noexcept:
     pass
     #format = PyBytes_FromString(fmt)
     #message = PyBytes_FromString(msg)
@@ -115,7 +115,7 @@ cdef void notice_h(char *fmt, char*msg):
     #    warn_msg = format
     #sys.stdout.write('GEOS_NOTICE: %s\n' % warn_msg)
 
-cdef void error_h(char *fmt, char*msg):
+cdef void error_h(char *fmt, char*msg) noexcept:
     format = PyBytes_FromString(fmt)
     message = PyBytes_FromString(msg)
     try:

--- a/packages/basemap/src/_geoslib.pyx
+++ b/packages/basemap/src/_geoslib.pyx
@@ -51,7 +51,10 @@ cdef extern from "geos_c.h":
         pass
     ctypedef struct GEOSCoordSeq:
         pass
-    ctypedef void (*GEOSMessageHandler)(char *fmt, char *list) noexcept
+    # Cython 3: Next ctypedef needs "noexcept" declaration unless
+    # the compiler directive "legacy_implicit_noexcept" is used
+    # ("noexcept" syntax supported since Cython 0.29.31).
+    ctypedef void (*GEOSMessageHandler)(char *fmt, char *list)
     char *GEOSversion()
     void initGEOS(GEOSMessageHandler notice_function, GEOSMessageHandler error_function)
     void finishGEOS()
@@ -105,7 +108,10 @@ cdef extern from "geos_c.h":
     GEOSCoordSeq  *GEOSGeom_getCoordSeq(GEOSGeom* g)
     int GEOSCoordSeq_getSize(GEOSCoordSeq *s, unsigned int *size)
 
-cdef void notice_h(char *fmt, char*msg) noexcept:
+# Cython 3: Next cdef needs "noexcept" declaration unless
+# the compiler directive "legacy_implicit_noexcept" is used
+# ("noexcept" syntax supported since Cython 0.29.31).
+cdef void notice_h(char *fmt, char*msg):
     pass
     #format = PyBytes_FromString(fmt)
     #message = PyBytes_FromString(msg)
@@ -115,7 +121,10 @@ cdef void notice_h(char *fmt, char*msg) noexcept:
     #    warn_msg = format
     #sys.stdout.write('GEOS_NOTICE: %s\n' % warn_msg)
 
-cdef void error_h(char *fmt, char*msg) noexcept:
+# Cython 3: Next cdef needs "noexcept" declaration unless
+# the compiler directive "legacy_implicit_noexcept" is used
+# ("noexcept" syntax supported since Cython 0.29.31).
+cdef void error_h(char *fmt, char*msg):
     format = PyBytes_FromString(fmt)
     message = PyBytes_FromString(msg)
     try:


### PR DESCRIPTION
The main issue seems to be that the `GEOSMessageHandler` function-pointer typedef, and the callbacks with matching signatures, need `noexcept`: https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept