### PR TITLE
Cibuild built from sdist -> wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,11 +235,43 @@ jobs:
         run: |
           python -m pip install build setuptools wheel
           mkdir -p /tmp/sdist_test
-          tar -xvf dist/*.tar.gz -C /tmp/sdist_test
+
+          # List all files in dist directory
+          echo "Files in dist directory:"
+          ls -la dist/
+
+          # Extract only the basemap sdist
+          BASEMAP_SDIST=$(ls dist/basemap-*.tar.gz 2>/dev/null || echo "")
+
+          if [ -z "$BASEMAP_SDIST" ]; then
+            echo "Basemap sdist not found with pattern 'basemap-*.tar.gz', trying alternative patterns..."
+            BASEMAP_SDIST=$(ls dist/*basemap*.tar.gz 2>/dev/null | head -1 || echo "")
+          fi
+
+          if [ -z "$BASEMAP_SDIST" ]; then
+            echo "ERROR: Could not find any basemap sdist"
+            exit 1
+          fi
+
+          echo "Using sdist: $BASEMAP_SDIST"
+
+          # Extract just the one sdist file
+          tar -xvf "$BASEMAP_SDIST" -C /tmp/sdist_test
+
+          # Enter extracted directory
           cd /tmp/sdist_test/*/
+
+          # Install and build
           python -m pip install -e .
           python -m build --wheel
-          ls -la dist/*.whl
+
+          # Check for built wheel
+          if [ -d "dist" ]; then
+            ls -la dist/*.whl || echo "No wheels found in dist directory"
+          else
+            echo "No dist directory created"
+            exit 1
+          fi
 
   upload:
     name: Upload packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,46 +230,23 @@ jobs:
           python -m twine check dist/*.tar.gz
           python -m twine check dist/*.whl
 
-      # Verification step to ensure sdist is complete
-      - name: Verify sdist can build wheel
+      - name: Verify sdist content
         run: |
-          python -m pip install build setuptools wheel
           mkdir -p /tmp/sdist_test
 
-          # List all files in dist directory
-          echo "Files in dist directory:"
-          ls -la dist/
-
-          # Extract only the basemap sdist
-          BASEMAP_SDIST=$(ls dist/basemap-*.tar.gz 2>/dev/null || echo "")
-
-          if [ -z "$BASEMAP_SDIST" ]; then
-            echo "Basemap sdist not found with pattern 'basemap-*.tar.gz', trying alternative patterns..."
-            BASEMAP_SDIST=$(ls dist/*basemap*.tar.gz 2>/dev/null | head -1 || echo "")
-          fi
-
-          if [ -z "$BASEMAP_SDIST" ]; then
-            echo "ERROR: Could not find any basemap sdist"
-            exit 1
-          fi
-
-          echo "Using sdist: $BASEMAP_SDIST"
-
-          # Extract just the one sdist file
+          # Find and extract basemap sdist
+          BASEMAP_SDIST=$(ls dist/basemap-*.tar.gz 2>/dev/null || ls dist/*basemap*.tar.gz 2>/dev/null | head -1)
           tar -xvf "$BASEMAP_SDIST" -C /tmp/sdist_test
 
-          # Enter extracted directory
-          cd /tmp/sdist_test/*/
+          # Verify contents
+          echo "Files in extracted sdist:"
+          find /tmp/sdist_test -type f | grep -v "__pycache__" | sort
 
-          # Install and build
-          python -m pip install -e .
-          python -m build --wheel
-
-          # Check for built wheel
-          if [ -d "dist" ]; then
-            ls -la dist/*.whl || echo "No wheels found in dist directory"
+          # Check for critical files
+          if [ -f "$(find /tmp/sdist_test -name "_geoslib.pyx")" ]; then
+            echo "✓ Source files verified in sdist"
           else
-            echo "No dist directory created"
+            echo "✗ Missing critical source files in sdist"
             exit 1
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,57 @@ jobs:
           name: basemap-sdist
           path: ./sdist/
 
+      - name: Download data packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-basemap_data*
+          path: ./data_packages/
+          merge-multiple: true
+
+      - name: Install data packages (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          # Debug - show what we downloaded
+          ls -la ./data_packages/
+
+          # Install the data packages
+          python -m pip install ./data_packages/*.whl
+
+          # Verify they're installed
+          python -c "import mpl_toolkits.basemap_data; print('Data package installed')"
+          python -c "import mpl_toolkits.basemap_data_hires; print('Hires data package installed')" || echo "Optional hires package not installed"
+
+      # Install the data packages (Windows)
+      - name: Install data packages (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # Debug - show what we downloaded
+          Get-ChildItem -Path "./data_packages" -Recurse
+
+          # Find all wheel files
+          $wheels = Get-ChildItem -Path "./data_packages" -Filter "*.whl" -Recurse
+
+          # Install each wheel file
+          foreach ($wheel in $wheels) {
+            Write-Host "Installing $($wheel.FullName)"
+            python -m pip install $wheel.FullName
+          }
+
+          # Verify they're installed
+          try {
+            python -c "import mpl_toolkits.basemap_data; print('Data package installed')"
+          } catch {
+            Write-Host "Error importing basemap_data"
+          }
+
+          try {
+            python -c "import mpl_toolkits.basemap_data_hires; print('Hires data package installed')"
+          } catch {
+            Write-Host "Optional hires package not installed"
+          }
+
       - name: Extract sdist (Linux/macOS)
         if: runner.os != 'Windows'
         shell: bash
@@ -148,6 +199,8 @@ jobs:
             PIP_PREFER_BINARY=1
             PYTHONUNBUFFERED=1
             LD_LIBRARY_PATH="${GEOS_DIR}/lib"
+          # LD_LIBRARY_PATH in environment is needed by
+          # auditwheel (Linux) and delocate (MacOS).
         with:
           package-dir: ${{ env.SDIST_DIR }} # Use extracted sdist
           output-dir: "dist"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,6 @@ jobs:
 
           # Verify they're installed
           python -c "import mpl_toolkits.basemap_data; print('Data package installed')"
-          python -c "import mpl_toolkits.basemap_data_hires; print('Hires data package installed')" || echo "Optional hires package not installed"
 
       # Install the data packages (Windows)
       - name: Install data packages (Windows)
@@ -124,18 +123,12 @@ jobs:
             python -m pip install $wheel.FullName
           }
 
-          # Verify they're installed
-          try {
-            python -c "import mpl_toolkits.basemap_data; print('Data package installed')"
-          } catch {
-            Write-Host "Error importing basemap_data"
-          }
+          # Show installed packages
+          python -m pip list | Select-String "mpl_toolkits.basemap"
 
-          try {
-            python -c "import mpl_toolkits.basemap_data_hires; print('Hires data package installed')"
-          } catch {
-            Write-Host "Optional hires package not installed"
-          }
+          # Try different import paths
+          Write-Host "Trying to import basemap_data..."
+          python -c "import mpl_toolkits.basemap_data; print('mpl_toolkits.basemap_data imported successfully')"
 
       - name: Extract sdist (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,31 @@ jobs:
             packages/${{ matrix.package }}/dist/*.whl
           name: dist-${{ matrix.package }}
 
-  build_basemap:
-    name: Build basemap package (${{ matrix.os }})
-    needs: [build_data]
+  build_sdist:
+    name: Build basemap sdist
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Build sdist
+        run: |
+          cd packages/basemap
+          python -m pip install build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: packages/basemap/dist/*.tar.gz
+          name: basemap-sdist
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    needs: [build_data, build_sdist]
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2019, macos-13, macos-14]
@@ -58,14 +80,58 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Build sdist
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          cd packages/basemap
-          python -m pip install build
-          python -m build --sdist
+      - name: Download basemap sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: basemap-sdist
+          path: ./sdist/
 
-      - name: Build wheels
+      - name: Extract sdist (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          # Create extraction directory in the workspace
+          mkdir -p ./sdist_extract
+
+          # Extract using tar (Unix-style)
+          tar -xvf ./sdist/*.tar.gz -C ./sdist_extract
+
+          # Get the extracted directory name
+          EXTRACTED_DIR=$(ls -d ./sdist_extract/*/ | head -1)
+          echo "SDIST_DIR=$(pwd)/${EXTRACTED_DIR}" >> $GITHUB_ENV
+
+          # Verify contents
+          ls -la ${EXTRACTED_DIR}
+
+      - name: Extract sdist (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # Create extraction directory
+          New-Item -ItemType Directory -Force -Path "sdist_extract"
+
+          # Find the tarball file (without using wildcards)
+          $tarball = Get-ChildItem -Path "sdist" -Filter "*.tar.gz" | Select-Object -First 1
+
+          # Debug - show what we found
+          Write-Host "Found tarball: $($tarball.FullName)"
+
+          # Extract using the specific file path (not wildcard)
+          tar -xvf $tarball.FullName -C "sdist_extract"
+
+          # Get the extracted directory name
+          $extractedDir = (Get-ChildItem -Path "sdist_extract" -Directory | Select-Object -First 1).FullName
+
+          # Debug - show what we found
+          Write-Host "Extracted directory: $extractedDir"
+
+          # Set the environment variable
+          echo "SDIST_DIR=$extractedDir" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+          # Verify contents
+          Get-ChildItem $extractedDir
+
+      - name: Build wheels from sdist
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ARCHS: "native"
@@ -82,22 +148,18 @@ jobs:
             PIP_PREFER_BINARY=1
             PYTHONUNBUFFERED=1
             LD_LIBRARY_PATH="${GEOS_DIR}/lib"
-          # LD_LIBRARY_PATH in environment is needed by
-          # auditwheel (Linux) and delocate (MacOS).
         with:
-          package-dir: "packages/basemap"
-          output-dir: "packages/basemap/dist"
+          package-dir: ${{ env.SDIST_DIR }} # Use extracted sdist
+          output-dir: "dist"
 
       - uses: actions/upload-artifact@v4
         with:
-          path: |
-            packages/basemap/dist/*.tar.gz
-            packages/basemap/dist/*.whl
-          name: dist-basemap-${{ matrix.os }}
+          path: dist/*.whl
+          name: dist-basemap-wheels-${{ matrix.os }}
 
   check:
     name: Check packages
-    needs: [build_data, build_basemap]
+    needs: [build_data, build_sdist, build_wheels]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@v4
@@ -105,6 +167,11 @@ jobs:
           path: dist
           pattern: "dist-*"
           merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          name: basemap-sdist
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -117,9 +184,20 @@ jobs:
           python -m twine check dist/*.tar.gz
           python -m twine check dist/*.whl
 
+      # Verification step to ensure sdist is complete
+      - name: Verify sdist can build wheel
+        run: |
+          python -m pip install build setuptools wheel
+          mkdir -p /tmp/sdist_test
+          tar -xvf dist/*.tar.gz -C /tmp/sdist_test
+          cd /tmp/sdist_test/*/
+          python -m pip install -e .
+          python -m build --wheel
+          ls -la dist/*.whl
+
   upload:
     name: Upload packages
-    needs: [build_data, build_basemap, check]
+    needs: [build_data, build_sdist, build_wheels, check]
     runs-on: ubuntu-22.04
     environment: PyPI
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -129,6 +207,11 @@ jobs:
           path: dist
           pattern: "dist-*"
           merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          name: basemap-sdist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR achieves two things.
First it builds the wheels directly from sdist rather than building the two separately.
Second, it ensures that cibuild will use the data and data_hires in the builds.

This was discussed on #611.