### PR TITLE
Fix incorrect docstring return order in shiftdata()

### DIFF
--- a/packages/basemap/src/mpl_toolkits/basemap/__init__.py
+++ b/packages/basemap/src/mpl_toolkits/basemap/__init__.py
@@ -4836,10 +4836,10 @@ class Basemap(object):
                          [lon_0-180, lon_0+180] range.
         ================ ======================================================
 
-        if datain given, returns ``dataout,lonsout`` (data and longitudes shifted to fit in interval
-        [lon_0-180,lon_0+180]), otherwise just returns longitudes.  If
-        transformed longitudes lie outside map projection region, data is
-        masked and longitudes are set to 1.e30.
+        If datain is given, returns ``lonsout, dataout`` (longitudes and data shifted to fit in the interval
+[lon_0-180, lon_0+180]); otherwise, returns just the shifted longitudes. If
+transformed longitudes lie outside the map projection region, data is
+masked and longitudes are set to 1.e30.
         """
         if lon_0 is None and 'lon_0' not in self.projparams:
             raise ValueError('lon_0 keyword must be provided')


### PR DESCRIPTION
Fixes #599. Updated the docstring in shiftdata() to correctly reflect the return value order as (lonsout, dataout) instead of (dataout, lonsout).