### PR TITLE
Fix compatibility with pyshp 3.0.0.

### DIFF
--- a/src/mpl_toolkits/basemap/__init__.py
+++ b/src/mpl_toolkits/basemap/__init__.py
@@ -2150,7 +2150,7 @@ class Basemap(object):
             "shapefile to geographic coordinates using the shpproj utility",
             "from the shapelib tools (http://shapelib.maptools.org/shapelib-tools.html)"])
         shptype = shf.shapes()[0].shapeType
-        bbox = shf.bbox.tolist()
+        bbox = list(shf.bbox)
         info = (shf.numRecords,shptype,bbox[0:2]+[0.,0.],bbox[2:]+[0.,0.])
         npoly = 0
         for shprec in shf.shapeRecords():


### PR DESCRIPTION
From the pyshp [README](https://github.com/GeospatialPython/pyshp/blob/3.0.0/README.md#breaking-changes):
> * bbox, mbox and zbox attributes are all new Namedtuples.

Namedtuples don't have `tolist()`, calling `list()` on `shapefile._Array` (pyshp < 3.0.0) and `tuple` (pyshp >= 3.0.0) produces the same result.

Fixes: #632