### PR TITLE
Fix value masking for (tri)contour.

### DIFF
--- a/src/mpl_toolkits/basemap/__init__.py
+++ b/src/mpl_toolkits/basemap/__init__.py
@@ -3538,8 +3538,8 @@ class Basemap(object):
                     masked=True
                 else:
                     masked=False
-                mask = np.logical_or(x<self.xmin,y<self.xmin) +\
-                       np.logical_or(x>self.xmax,y>self.xmax)
+                mask = np.logical_and(np.logical_and(x>=self.xmin, x<=self.xmax),
+                                      np.logical_and(y>=self.ymin, y<=self.ymax))
                 x = np.compress(mask,x)
                 y = np.compress(mask,y)
                 data = np.compress(mask,data)


### PR DESCRIPTION
This has been broken for a looong time it seems. But this PR should fix #265

Thanks to @jypeter for the original issue and fix.